### PR TITLE
look for .markdown extension in task

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -42,7 +42,7 @@
         tmp (boot/tmp-dir!)
         options (merge +markdown-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [markdown-files (->> fileset boot/user-files (boot/by-ext [".md"]) (map #(.getPath (boot/tmp-file %))))]
+      (let [markdown-files (->> fileset boot/user-files (boot/by-ext ["md" "markdown"]) (map #(.getPath (boot/tmp-file %))))]
         (pod/with-call-in @pod
           (io.perun.markdown/parse-markdown
             ~(.getPath tmp)


### PR DESCRIPTION
Not 100% convinced about looking for multiple file extensions but given that the maintenance overhead of this is zero, it's probably fine.

Something else I found on the topic: http://daringfireball.net/linked/2014/01/08/markdown-extension
