### PR TITLE
change format of markdown metadata

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,6 @@
                   [jeluard/boot-notify "0.1.2" :scope "test"]
                   [clj-time "0.9.0" :scope "test"]
                   [markdown-clj "0.9.40" :scope "test"]
-                  [endophile "0.1.2" :scope "test"]
                   [time-to-read "0.1.0" :scope "test"]
                   [sitemap "0.2.4" :scope "test"]
                   [clj-rss "0.1.9" :scope "test"]])
@@ -14,7 +13,7 @@
 (require '[adzerk.bootlaces :refer :all])
 
 
-(def +version+ "0.1.0-SNAPSHOT")
+(def +version+ "0.1.1-SNAPSHOT")
 (bootlaces! +version+)
 
 (task-options!

--- a/build.boot
+++ b/build.boot
@@ -6,6 +6,7 @@
                   [jeluard/boot-notify "0.1.2" :scope "test"]
                   [clj-time "0.9.0" :scope "test"]
                   [markdown-clj "0.9.40" :scope "test"]
+                  [circleci/clj-yaml "0.5.3" :scope "test"]
                   [time-to-read "0.1.0" :scope "test"]
                   [sitemap "0.2.4" :scope "test"]
                   [clj-rss "0.1.9" :scope "test"]])

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -22,8 +22,7 @@
   (->> fileset boot/input-files (boot/by-name [filename]) first))
 
 (def ^:private markdown-deps
-  '[[markdown-clj "0.9.40"]
-    [endophile "0.1.2"]])
+  '[[markdown-clj "0.9.40"]])
 
 (def ^:private +markdown-defaults+
   (merge +defaults+

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -22,7 +22,8 @@
   (->> fileset boot/input-files (boot/by-name [filename]) first))
 
 (def ^:private markdown-deps
-  '[[markdown-clj "0.9.40"]])
+  '[[markdown-clj "0.9.40"]
+    [circleci/clj-yaml "0.5.3"]])
 
 (def ^:private +markdown-defaults+
   (merge +defaults+

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -23,7 +23,7 @@
       first))
 
 (defn parse-file-metadata [file-content]
-  (let [metadata-str (extract-between file-content #"---" #"---")
+  (let [metadata-str (extract-between file-content #"---\n" #"---\n")
         parsed-yaml (yaml/parse-string metadata-str)]
     ; we use `original` file flag to distinguish between generated files
     ; (e.x. created those by plugins)

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -2,8 +2,7 @@
   (:require [boot.util       :as u]
             [io.perun.core   :as perun]
             [clojure.java.io :as io]
-            [markdown.core   :as markdown-converter]
-            [endophile.core  :as markdown-parser]))
+            [markdown.core   :as markdown-converter]))
 
 
 (defn generate-filename
@@ -15,51 +14,59 @@
         short-name (subs filename 9 (- length 3))]
         short-name))
 
-
-(defn file-to-clj [file]
-  (-> file
-      slurp
-      markdown-parser/mp
-      markdown-parser/to-clj
-      first))
-
 (defn trim-if-not-nil [s]
   (if (clojure.string/blank? s)
     s
     (clojure.string/trim s)))
 
 
-(defn parse-file-defn [lines]
-  ; we use `original` file flag to distinguish between generated files
-  ; (e.x. created those by plugins)
-  (let [metadata {:original true}]
-        (into metadata
-          (for [line lines]
-            (let [tokens (clojure.string/split line #":" 2)
-                  key-token (trim-if-not-nil (first tokens))
-                  value-token (trim-if-not-nil (second tokens))]
-                  (if (not (clojure.string/blank? key-token))
-                    [(keyword key-token) value-token]))))))
+(defn extract-between [s prefix suffix]
+  (-> s
+      (clojure.string/split prefix)
+      second
+      (clojure.string/split suffix)
+      first))
 
+
+(defn parse-file-metadata [content]
+  (let [metadata-str (extract-between content #"---" #"---")
+        metadata-lines (clojure.string/split metadata-str #"\n")
+        ; we use `original` file flag to distinguish between generated files
+        ; (e.x. created those by plugins)
+        metadata {:original true}]
+    (into metadata
+      (for [line metadata-lines]
+        (let [tokens (clojure.string/split line #":" 2)
+              key-token (trim-if-not-nil (first tokens))
+              value-token (trim-if-not-nil (second tokens))]
+              (if (not (clojure.string/blank? key-token))
+                [(keyword key-token) value-token]))))))
+
+(defn file-to-metadata [file]
+  (-> file
+      slurp
+      parse-file-metadata))
+
+(defn remove-metadata [content]
+  (first (drop 2 (clojure.string/split content #"---"))))
 
 (defn markdown-to-html [file]
   (-> file
       slurp
+      remove-metadata
       markdown-converter/md-to-html-string))
 
 ; TODO we need to validate that create-filename is a function
 (defn process-file [file options]
-  (if-let [file-def (file-to-clj file)]
-    (if-let [data (:data file-def)]
-      (let [lines (clojure.string/split data #"\n")
-            create-filename-fn (eval (read-string (:create-filename options)))
-            filename (create-filename-fn file)
-            metadata (parse-file-defn lines)
-            content (markdown-to-html file)]
+  (if-let [metadata (file-to-metadata file)]
+    (let [create-filename-fn (eval (read-string (:create-filename options)))
+          filename (create-filename-fn file)
+          content (markdown-to-html file)]
         (assoc metadata :filename filename
-                        :content content)))))
+                        :content content))))
 
 (defn parse-markdown [markdown-files options]
-  (let [parsed-files (map #(process-file (io/file %) options) markdown-files)]
+  (let [parsed-files (map #(process-file (io/file %) options) markdown-files)
+        files (remove nil? parsed-files)]
     (u/info "Parsed %s markdown files\n" (count markdown-files))
-    parsed-files))
+    files))

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -2,6 +2,7 @@
   (:require [boot.util       :as u]
             [io.perun.core   :as perun]
             [clojure.java.io :as io]
+            [clojure.string  :as str]
             [markdown.core   :as markdown-converter]))
 
 
@@ -30,16 +31,16 @@
 
 (defn parse-file-metadata [content]
   (let [metadata-str (extract-between content #"---" #"---")
-        metadata-lines (clojure.string/split metadata-str #"\n")
+        metadata-lines (str/split metadata-str #"\n")
         ; we use `original` file flag to distinguish between generated files
         ; (e.x. created those by plugins)
         metadata {:original true}]
     (into metadata
       (for [line metadata-lines]
-        (let [tokens (clojure.string/split line #":" 2)
+        (let [tokens (str/split line #":" 2)
               key-token (trim-if-not-nil (first tokens))
               value-token (trim-if-not-nil (second tokens))]
-              (if (not (clojure.string/blank? key-token))
+              (if (not (str/blank? key-token))
                 [(keyword key-token) value-token]))))))
 
 (defn file-to-metadata [file]
@@ -48,7 +49,7 @@
       parse-file-metadata))
 
 (defn remove-metadata [content]
-  (first (drop 2 (clojure.string/split content #"---"))))
+  (first (drop 2 (str/split content #"---"))))
 
 (defn markdown-to-html [file]
   (-> file


### PR DESCRIPTION
Implementation for the https://github.com/hashobject/perun/issues/8.

Now markdown metadata should be specified in the Jekyll style.
It's good because GitHub hash special support for such style.
