### PR TITLE
Change metadata format

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -9,13 +9,12 @@
                   [endophile "0.1.2" :scope "test"]
                   [time-to-read "0.1.0" :scope "test"]
                   [sitemap "0.2.4" :scope "test"]
-                  [clj-rss "0.1.9" :scope "test"]
-                  [metosin/potpuri "0.2.2" :scope "test"]])
+                  [clj-rss "0.1.9" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 
 
-(def +version+ "0.1.0-SNAPSHOT")
+(def +version+ "0.1.1-SNAPSHOT")
 (bootlaces! +version+)
 
 (task-options!

--- a/build.boot
+++ b/build.boot
@@ -9,7 +9,8 @@
                   [endophile "0.1.2" :scope "test"]
                   [time-to-read "0.1.0" :scope "test"]
                   [sitemap "0.2.4" :scope "test"]
-                  [clj-rss "0.1.9" :scope "test"]])
+                  [clj-rss "0.1.9" :scope "test"]
+                  [metosin/potpuri "0.2.2" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -3,10 +3,12 @@
   (:require [boot.core :as boot :refer [deftask]]
             [boot.pod :as pod]
             [boot.util :as u]
-            [io.perun.core :as perun]))
+            [io.perun.core :as perun]
+            [potpuri.core :as potpuri]))
 
 (def ^:private global-deps
-  '[[clj-time "0.9.0"]])
+  '[[clj-time "0.9.0"]
+    [metosin/potpuri "0.2.2"]])
 
 (def ^:private
   +defaults+ {})
@@ -66,10 +68,10 @@
   "Exclude draft files"
   []
   (boot/with-pre-wrap fileset
-    (let [files-metadata (:metadata (meta fileset))
-          updated-metadata (into {} (remove #(true? (:draft (val %))) files-metadata))
-          fs-with-meta (with-meta fileset {:metadata updated-metadata})]
-      (u/info "Remove draft files. Remaining %s files\n" (count updated-metadata))
+    (let [files (:metadata (meta fileset))
+          updated-files (potpuri/filter-vals #(not (true? (:draft %))) files)
+          fs-with-meta (with-meta fileset {:metadata updated-files})]
+      (u/info "Remove draft files. Remaining %s files\n" (count updated-files))
       fs-with-meta)))
 
 (defn- create-filepath [file options]
@@ -82,7 +84,7 @@
   (let [options (merge +defaults+ *opts*)]
     (boot/with-pre-wrap fileset
       (let [files (:metadata (meta fileset))
-            updated-files (perun/update-map files #(create-filepath % options))
+            updated-files (potpuri/map-vals #(create-filepath % options) files)
             fs-with-meta (with-meta fileset {:metadata updated-files})]
         (u/info "Added permalinks to %s files\n" (count updated-files))
         fs-with-meta))))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -67,7 +67,7 @@
   []
   (boot/with-pre-wrap fileset
     (let [files-metadata (:metadata (meta fileset))
-          updated-metadata (remove #(true? (:draft %)) files-metadata)
+          updated-metadata (into {} (remove #(true? (:draft (val %))) files-metadata))
           fs-with-meta (with-meta fileset {:metadata updated-metadata})]
       (u/info "Remove draft files. Remaining %s files\n" (count updated-metadata))
       fs-with-meta)))
@@ -81,10 +81,10 @@
   []
   (let [options (merge +defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files-metadata (:metadata (meta fileset))
-            updated-metadata (map #(create-filepath % options) files-metadata)
-            fs-with-meta (with-meta fileset {:metadata updated-metadata})]
-        (u/info "Added permalinks to %s files\n" (count updated-metadata))
+      (let [files (:metadata (meta fileset))
+            updated-files (perun/update-map files #(create-filepath % options))
+            fs-with-meta (with-meta fileset {:metadata updated-files})]
+        (u/info "Added permalinks to %s files\n" (count updated-files))
         fs-with-meta))))
 
 (def ^:private sitemap-deps
@@ -150,8 +150,8 @@
   (let [tmp (boot/tmp-dir!)
         options (merge +render-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files-metadata (:metadata (meta fileset))]
-        (doseq [file files-metadata]
+      (let [files (vals (:metadata (meta fileset)))]
+        (doseq [file files]
           (let [render-fn (:renderer options)
                 html (render-fn file)
                 page-filepath (str (:target options) "/"
@@ -179,9 +179,9 @@
   (let [tmp (boot/tmp-dir!)
         options (merge +collection-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files-metadata (:metadata (meta fileset))
-            filtered-files (filter (:filterer options) files-metadata)
-            sorted-files (sort-by (:sortby options) (:comparator options) files-metadata)
+      (let [files (vals (:metadata (meta fileset)))
+            filtered-files (filter (:filterer options) files)
+            sorted-files (sort-by (:sortby options) (:comparator options) filtered-files)
             render-fn (:renderer options)
             html (render-fn sorted-files)
             page-filepath (str (:target options) "/" page)]

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -3,12 +3,10 @@
   (:require [boot.core :as boot :refer [deftask]]
             [boot.pod :as pod]
             [boot.util :as u]
-            [io.perun.core :as perun]
-            [potpuri.core :as potpuri]))
+            [io.perun.core :as perun]))
 
 (def ^:private global-deps
-  '[[clj-time "0.9.0"]
-    [metosin/potpuri "0.2.2"]])
+  '[[clj-time "0.9.0"]])
 
 (def ^:private
   +defaults+ {})
@@ -69,7 +67,7 @@
   []
   (boot/with-pre-wrap fileset
     (let [files (:metadata (meta fileset))
-          updated-files (potpuri/filter-vals #(not (true? (:draft %))) files)
+          updated-files (perun/filter-vals #(not (true? (:draft %))) files)
           fs-with-meta (with-meta fileset {:metadata updated-files})]
       (u/info "Remove draft files. Remaining %s files\n" (count updated-files))
       fs-with-meta)))
@@ -84,7 +82,7 @@
   (let [options (merge +defaults+ *opts*)]
     (boot/with-pre-wrap fileset
       (let [files (:metadata (meta fileset))
-            updated-files (potpuri/map-vals #(create-filepath % options) files)
+            updated-files (perun/map-vals #(create-filepath % options) files)
             fs-with-meta (with-meta fileset {:metadata updated-files})]
         (u/info "Added permalinks to %s files\n" (count updated-files))
         fs-with-meta))))

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -2,10 +2,6 @@
   "Utilies which can be used in base JVM and pods."
   (:require [clojure.java.io :as io]))
 
-(defn update-map [m f]
-  (reduce-kv (fn [m k v]
-    (assoc m k (f v))) {} m))
-
 (defn write-to-file [out-file content]
   (doto out-file
     io/make-parents

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -2,6 +2,10 @@
   "Utilies which can be used in base JVM and pods."
   (:require [clojure.java.io :as io]))
 
+(defn update-map [m f]
+  (reduce-kv (fn [m k v]
+    (assoc m k (f v))) {} m))
+
 (defn write-to-file [out-file content]
   (doto out-file
     io/make-parents

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -10,3 +10,47 @@
 (defn create-file [tmp filepath content]
   (let [file (io/file tmp filepath)]
     (write-to-file file content)))
+
+;;;; map for kv collections
+
+;; These are like ones in medley
+
+;; borrowed from https://github.com/metosin/potpuri/blob/master/src/potpuri/core.cljx#L203-L240
+
+(defn- editable? [coll]
+  (instance? clojure.lang.IEditableCollection coll))
+
+(defn- reduce-map [f coll]
+  (if (editable? coll)
+    (persistent! (reduce-kv (f assoc!) (transient (empty coll)) coll))
+    (reduce-kv (f assoc) (empty coll) coll)))
+
+(defn map-keys
+  "Map the keys of given associative collection using function."
+  {:added "0.2.0"}
+  [f coll]
+  (reduce-map (fn [xf] (fn [m k v]
+                         (xf m (f k) v)))
+              coll))
+
+(defn map-vals
+  "Map the values of given associative collection using function."
+  {:added "0.2.0"}
+  [f coll]
+  (reduce-map (fn [xf] (fn [m k v]
+                         (xf m k (f v))))
+              coll))
+
+(defn filter-keys
+  {:added "0.2.2"}
+  [pred coll]
+  (reduce-map (fn [xf] (fn [m k v]
+                         (if (pred k) (xf m k v) m)))
+              coll))
+
+(defn filter-vals
+  {:added "0.2.2"}
+  [pred coll]
+  (reduce-map (fn [xf] (fn [m k v]
+                         (if (pred v) (xf m k v) m)))
+              coll))

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -55,11 +55,13 @@
             create-filename-fn (eval (read-string (:create-filename options)))
             filename (create-filename-fn file)
             metadata (parse-file-defn lines)
-            content (markdown-to-html file)]
-        (assoc metadata :filename filename
-                        :content content)))))
+            content (markdown-to-html file)
+            updated-meta (assoc metadata
+                                  :filename filename
+                                  :content content)]
+        [(.getName file) updated-meta]))))
 
 (defn parse-markdown [markdown-files options]
-  (let [parsed-files (map #(process-file (io/file %) options) markdown-files)]
-    (u/info "Parsed %s markdown files\n" (count markdown-files))
+  (let [parsed-files (into {} (map #(process-file (io/file %) options) markdown-files))]
+    (u/info (prn-str parsed-files))
     parsed-files))

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -63,5 +63,5 @@
 
 (defn parse-markdown [markdown-files options]
   (let [parsed-files (into {} (map #(process-file (io/file %) options) markdown-files))]
-    (u/info (prn-str parsed-files))
+    (u/info "Parsed %s markdown files\n" (count markdown-files))
     parsed-files))

--- a/src/io/perun/rss.clj
+++ b/src/io/perun/rss.clj
@@ -6,7 +6,7 @@
             [clj-rss.core    :as rss-gen]))
 
 (defn rss-definitions [files]
-  (for [file files]
+  (for [file (vals files)]
     {:link (:canonical_url file)
      :guid (:canonical_url file)
      :pubDate (date/str-to-date (:date_published file))
@@ -20,9 +20,9 @@
         rss-str (apply rss-gen/channel-xml opts items)]
     rss-str))
 
-(defn generate-rss [tgt-path files-metadata options]
+(defn generate-rss [tgt-path files options]
   (let [rss-filepath (str (:target options) "/" (:filename options))
-        rss-string (generate-rss-str files-metadata options)]
+        rss-string (generate-rss-str files options)]
     (perun/create-file tgt-path rss-filepath rss-string)
     (u/info "Generate RSS feed and save to %s\n" rss-filepath)))
 

--- a/src/io/perun/sitemap.clj
+++ b/src/io/perun/sitemap.clj
@@ -11,7 +11,7 @@
        :lastmod (:date_modified file)
        :changefreq (or (:sitemap_changefreq file) "weekly")
        :priority (or (:sitemap_priority file) 0.8)})
-    files))
+    (vals files)))
 
 (defn generate-sitemap [tgt-path files-metadata options]
   (let [sitemap-filepath (str (:target options) "/" (:filename options))

--- a/src/io/perun/ttr.clj
+++ b/src/io/perun/ttr.clj
@@ -1,12 +1,12 @@
 (ns io.perun.ttr
   (:require [boot.util         :as u]
-            [potpuri.core      :as potpuri]
+            [io.perun.core     :as perun]
             [time-to-read.core :as time-to-read]))
 
 
 (defn calculate-ttr [files]
   (let [updated-files
-          (potpuri/map-vals
+          (perun/map-vals
             (fn [metadata]
               (assoc metadata :ttr (time-to-read/estimate-for-text (:content metadata))))
             files)]

--- a/src/io/perun/ttr.clj
+++ b/src/io/perun/ttr.clj
@@ -1,13 +1,14 @@
 (ns io.perun.ttr
   (:require [boot.util         :as u]
-            [io.perun.core     :as perun]
+            [potpuri.core      :as potpuri]
             [time-to-read.core :as time-to-read]))
 
 
 (defn calculate-ttr [files]
   (let [updated-files
-          (perun/update-map files
+          (potpuri/map-vals
             (fn [metadata]
-              (assoc metadata :ttr (time-to-read/estimate-for-text (:content metadata)))))]
+              (assoc metadata :ttr (time-to-read/estimate-for-text (:content metadata))))
+            files)]
     (u/info "Added TTR to %s files\n" (count updated-files))
     updated-files))

--- a/src/io/perun/ttr.clj
+++ b/src/io/perun/ttr.clj
@@ -2,12 +2,13 @@
   (:require [boot.util         :as u]
             [time-to-read.core :as time-to-read]))
 
-(defn calculate-ttr [files-metadata]
-  (let [updated-metadata
+(defn calculate-ttr [files]
+  (let [updated-files
         (map
-          (fn [metadata]
-            (let [time-to-read (time-to-read/estimate-for-text (:content metadata))]
+          (fn [file]
+            (let [metadata (val file)
+                  time-to-read (time-to-read/estimate-for-text (:content metadata))]
               (assoc metadata :ttr time-to-read)))
-          files-metadata)]
-    (u/info "Added TTR to %s files\n" (count updated-metadata))
-    updated-metadata))
+          files)]
+    (u/info "Added TTR to %s files\n" (count updated-files))
+    updated-files))

--- a/src/io/perun/ttr.clj
+++ b/src/io/perun/ttr.clj
@@ -1,14 +1,13 @@
 (ns io.perun.ttr
   (:require [boot.util         :as u]
+            [io.perun.core     :as perun]
             [time-to-read.core :as time-to-read]))
+
 
 (defn calculate-ttr [files]
   (let [updated-files
-        (map
-          (fn [file]
-            (let [metadata (val file)
-                  time-to-read (time-to-read/estimate-for-text (:content metadata))]
-              (assoc metadata :ttr time-to-read)))
-          files)]
+          (perun/update-map files
+            (fn [metadata]
+              (assoc metadata :ttr (time-to-read/estimate-for-text (:content metadata)))))]
     (u/info "Added TTR to %s files\n" (count updated-files))
     updated-files))


### PR DESCRIPTION
New format was proposed in #2.

Now instead of list of meta-data entries for all files we have a map like this:

```
{"/post1.md" {:name "Post 1"} "/post2.md" {:name "Post 2"}}
```
