### PR TITLE
replace markdown-clj with endophile

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -22,7 +22,7 @@
   (->> fileset boot/input-files (boot/by-name [filename]) first))
 
 (def ^:private markdown-deps
-  '[[markdown-clj "0.9.67"]
+  '[[endophile "0.1.2"]
     [circleci/clj-yaml "0.5.3"]])
 
 (def ^:private +markdown-defaults+

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -48,14 +48,11 @@
 (defn process-file [file options]
   (let [file-content (slurp file)
         metadata     (parse-file-metadata file-content)
-        create-filename-fn (eval (read-string (:create-filename options)))
-        filename     (create-filename-fn file)
-        content      (markdown-to-html file-content)
-        updated-meta (assoc metadata
-                              :filename filename
-                              :content content)]
+        create-filename-fn (eval (read-string (:create-filename options)))]
       (u/info "Processing Markdown: %s\n" (.getName file))
-      [(.getName file) updated-meta]))
+      [(.getName file) (assoc metadata
+                              :filename (create-filename-fn file)
+                              :content (markdown-to-html file-content))]))
 
 (defn parse-markdown [markdown-files options]
   (let [parsed-files (into {} (map #(process-file (io/file %) options) markdown-files))]

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -3,7 +3,7 @@
             [io.perun.core   :as perun]
             [clojure.java.io :as io]
             [clojure.string  :as str]
-            [markdown.core   :as markdown-converter]
+            [endophile.core  :as endophile]
             [clj-yaml.core   :as yaml]))
 
 (defn generate-filename
@@ -38,21 +38,23 @@
       content)))
 
 (defn markdown-to-html [file-content]
-  (u/info file-content)
   (-> file-content
       remove-metadata
-      markdown-converter/md-to-html-string))
+      endophile/mp
+      endophile/to-clj
+      endophile/html-string))
 
 ; TODO we need to validate that create-filename is a function
 (defn process-file [file options]
   (let [file-content (slurp file)
-        metadata (parse-file-metadata file-content)
+        metadata     (parse-file-metadata file-content)
         create-filename-fn (eval (read-string (:create-filename options)))
-        filename (create-filename-fn file)
-        content (markdown-to-html file-content)
+        filename     (create-filename-fn file)
+        content      (markdown-to-html file-content)
         updated-meta (assoc metadata
                               :filename filename
                               :content content)]
+      (u/info "Processing Markdown: %s\n" (.getName file))
       [(.getName file) updated-meta]))
 
 (defn parse-markdown [markdown-files options]


### PR DESCRIPTION
This worked as a drop in replacement for me, properly processing and outputting many things `markdown-clj` did not parse as expected.
