### PR TITLE
Change collection comparator default

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -196,7 +196,7 @@
   {:out-dir "public"
    :filterer identity
    :sortby (fn [file] (:date-published file))
-   :comparator (fn [i1 i2] (compare i1 i2))})
+   :comparator (fn [i1 i2] (compare i2 i1))})
 
 (deftask collection
   "Render collection files"


### PR DESCRIPTION
Currently the default is `(fn [i1 i2] (compare i1 i2))`. With the assumption that in most cases this function will get two date strings like `20130512` or `2015-03-10` and people usually want to sort those most-recent-first I'd suggest changing the comparator function to `(fn [i1 i2] (compare i2 i1))`.
