### PR TITLE
Add readme section on auto-deployment to S3 using GitHub and Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ After you created `build` task simply do:
   boot build
 ```
 
+## Tips
+
+### Auto deployment
+
+It's quite easy to setup automatic static site deployment.
+E.x. you have GitHub repo for your blog and you are using `boot-s3` to sync files to Amazon S3.
+In this case it's possible to setup flow in a way that every commit to GitHub would be deployed
+to AWS S3.
+
+Assuming you have setup similar to [example](https://github.com/hashobject/blog.hashobject.com/blob/master/build.boot#L31)in order to achieve this you need to:
+ - setup [Heroku](heroku.com) application. Don't forget to specify ENVs
+ - add boot buildpack `heroku buildpacks:add https://github.com/upworthy/heroku-buildpack-boot`
+ - enable GitHub integration https://devcenter.heroku.com/articles/github-integration
+ - change your site in GitHub and see changes deployed to AWS
+
 
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ In this case it's possible to setup flow in a way that every commit to GitHub wo
 perun and deployed to AWS S3.
 
 Assuming you have setup similar to [example](https://github.com/hashobject/blog.hashobject.com/blob/master/build.boot#L31)in order to achieve this you need to:
- - setup [Heroku](heroku.com) application.
+ - create [Heroku](heroku.com) application for your GitHub repo with `build.boot` file
+ - ensure that `build.boot` has `build` task that has tasks build and deploy tasks
  - specify `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` envs. They are mandatory for the `boot-s3` plugin).
  - add boot/perun buildpack `heroku buildpacks:add https://github.com/hashobject/heroku-buildpack-perun`
  - enable GitHub integration https://devcenter.heroku.com/articles/github-integration

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ In this case it's possible to setup flow in a way that every commit to GitHub wo
 to AWS S3.
 
 Assuming you have setup similar to [example](https://github.com/hashobject/blog.hashobject.com/blob/master/build.boot#L31)in order to achieve this you need to:
- - setup [Heroku](heroku.com) application. Don't forget to specify ENVs
+ - setup [Heroku](heroku.com) application. Don't forget to specify ENVs for your tasks (e.x. `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`)
  - add boot buildpack `heroku buildpacks:add https://github.com/upworthy/heroku-buildpack-boot`
  - enable GitHub integration https://devcenter.heroku.com/articles/github-integration
  - change your site in GitHub and see changes deployed to AWS

--- a/README.md
+++ b/README.md
@@ -153,15 +153,15 @@ After you created `build` task simply do:
 
 It's quite easy to setup automatic static site deployment.
 E.x. you have GitHub repo for your blog and you are using `boot-s3` to sync files to Amazon S3.
-In this case it's possible to setup flow in a way that every commit to GitHub would be deployed
-to AWS S3.
+In this case it's possible to setup flow in a way that every commit to GitHub would be build om Heroku using
+perun and deployed to AWS S3.
 
 Assuming you have setup similar to [example](https://github.com/hashobject/blog.hashobject.com/blob/master/build.boot#L31)in order to achieve this you need to:
- - setup [Heroku](heroku.com) application. Don't forget to specify ENVs for your tasks (e.x. `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`)
- - add boot buildpack `heroku buildpacks:add https://github.com/upworthy/heroku-buildpack-boot`
+ - setup [Heroku](heroku.com) application.
+ - specify `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` envs. They are mandatory for the `boot-s3` plugin).
+ - add boot/perun buildpack `heroku buildpacks:add https://github.com/hashobject/heroku-buildpack-perun`
  - enable GitHub integration https://devcenter.heroku.com/articles/github-integration
- - change your site in GitHub and see changes deployed to AWS
-
+ - change your site in GitHub and see changes deployed to AWS S3 in few minutes
 
 
 ## TODO


### PR DESCRIPTION
It's possible to configure auto-deployment of all all changes from GitHub repo to S3.
Heroku will run `boot build` and push content generated by perun to S3.
