### PR TITLE
Add base-metadata and canonical-url tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ that suits your needs.
 ## Plugins
 
  - markdown - parse mardown files with YAML metadata
+ - global-metadata - read global metadata from `perun.base.edn`
  - collections - generate page that takes all posts data as parameter
  - drafts - exclude pages that have `:draft` flag
  - time-to-read - calculate time to read for each page
  - sitemap - generate sitemap for site
  - rss - generate RSS feed
  - slugs - generate slugs based on any property
- - permalinks - create permalinks for each page
+ - permalink - create permalink for each page
+ - canonical-url - create canonical-url for each page
  - gravatar - find gravatar urls using emails
  - rendering to any format - flexible rendering
 
@@ -124,9 +126,9 @@ See documentation for each task to find all supported options for each plugin.
 (require '[hashobject.boot-s3 :refer :all])
 (require '[jeluard.boot-notify :refer [notify]])
 
-(defn renderer [data] (:name data))
+(defn renderer [global data] (:name data))
 
-(defn index-renderer [files]
+(defn index-renderer [global files]
   (let [names (map :name files)]
     (clojure.string/join "\n" names)))
 

--- a/build.boot
+++ b/build.boot
@@ -33,10 +33,10 @@
 
 
 ; testing functions
-(defn renderer [data]
+(defn renderer [global data]
   (:content data))
 
-(defn index-renderer [files]
+(defn index-renderer [global files]
   (let [names (map :name files)]
     (clojure.string/join "\n" names)))
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -58,15 +58,19 @@
         (reset! prev-meta final-metadata)
         fs-with-meta))))
 
-(deftask base-metadata
-  "Read global metadata from `perun.base.edn` file."
-  []
+(deftask global-metadata
+  "Read global metadata from `perun.base.edn` or configured file.
+
+   The global metadata will be attached to fileset where it can be
+   read and manipulated by the tasks. Render tasks will pass this
+   as the first argument to render functions."
+  [n filename NAME str "filename where to read global metadata"]
   (boot/with-pre-wrap fileset
     (perun/set-global-meta
       fileset
       (some->> fileset
                boot/user-files
-               (boot/by-name ["perun.base.edn"])
+               (boot/by-name [(or filename "perun.base.edn")])
                first
                boot/tmp-file
                slurp
@@ -160,7 +164,7 @@
 (deftask canonical-url
   "Adds :canonical-url key to files metadata.
 
-   The url is concatenation of :base-url in global metadata and files permaurl.
+   The url is concatenation of :base-url in global metadata and files' permaurl.
    The base-url must end with '/'."
   []
   (boot/with-pre-wrap fileset

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -8,8 +8,16 @@
 (defn get-perun-meta [fileset]
   (-> fileset meta +perun-meta-key+))
 
-(defn with-perun-meta [fileset perun-data]
-  (with-meta fileset (assoc (meta fileset) +perun-meta-key+ perun-data)))
+(defn with-perun-meta [fileset data]
+  (vary-meta fileset assoc +perun-meta-key+ data))
+
+(def +global-meta-key+ :io.perun.global)
+
+(defn get-global-meta [fileset]
+  (-> fileset meta +global-meta-key+))
+
+(defn set-global-meta [fileset data]
+  (vary-meta fileset assoc +global-meta-key+ data))
 
 (defn write-to-file [out-file content]
   (doto out-file

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -3,13 +3,13 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]))
 
-(def +perun-meta-key+ :io.perun)
+(def +meta-key+ :io.perun)
 
-(defn get-perun-meta [fileset]
-  (-> fileset meta +perun-meta-key+))
+(defn get-meta [fileset]
+  (-> fileset meta +meta-key+))
 
-(defn with-perun-meta [fileset data]
-  (vary-meta fileset assoc +perun-meta-key+ data))
+(defn set-meta [fileset data]
+  (vary-meta fileset assoc +meta-key+ data))
 
 (def +global-meta-key+ :io.perun.global)
 


### PR DESCRIPTION
Fixes #14 and #41 

**Before merging** we should decide one name for this, currently the code uses both `base-metadata` and `global-meta` and I can't decide which is better.

**Breaks** existing render functions as they are now called with two arguments, global meta and files or file. I don't see way around this as it's not possible to attach the metadata to collections.
