### PR TITLE
update markdown plugin to insert anchors automatically

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -5,6 +5,8 @@
                   [adzerk/bootlaces "0.1.9" :scope "test"]
                   [jeluard/boot-notify "0.1.2" :scope "test"]
                   [endophile "0.1.2" :scope "test"]
+                  [enlive "1.1.5" :scope "test"]
+                  [camel-snake-kebab "0.3.2" :scope "test"]
                   [circleci/clj-yaml "0.5.3" :scope "test"]
                   [time-to-read "0.1.0" :scope "test"]
                   [sitemap "0.2.4" :scope "test"]

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -25,6 +25,8 @@
 
 (def ^:private markdown-deps
   '[[endophile "0.1.2"]
+    [enlive "1.1.5"]
+    [camel-snake-kebab "0.3.2"]
     [circleci/clj-yaml "0.5.3"]])
 
 (deftask markdown


### PR DESCRIPTION
**Note:** This is not final implementation.

This PR updates Markdown plugin to automatically replace all headers.
Following transformation would happen:

``` html
<h1>Header</h1>
```

would be replaced with

``` html
<h1><a href="#header"><span></span>Header</h1>
```

This is needed to be able to share link to the particular part of the page.

TBD:

Unfortunately it wasn't possible to make it as separate plugin (since markdown parsing and html generation are bundled into one task).

So this was implemented as part of `markdown` task itself. We can make it optional.
Also we can allow customization of the output transformation.
