### PR TITLE
allow more versatile collection rendering via group-by

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -319,6 +319,7 @@
 (def ^:private +collection-defaults+
   {:out-dir "public"
    :filterer identity
+   :groupby (fn [x] "index.html")
    :sortby (fn [file] (:date-published file))
    :comparator (fn [i1 i2] (compare i2 i1))})
 
@@ -328,15 +329,21 @@
    r renderer   RENDERER   sym  "Page renderer. Fully qualified symbol resolving to a function."
    f filterer   FILTER     code "Filter function"
    s sortby     SORTBY     code "Sort by function"
+   g groupby    GROUPBY    code "Group posts by function, keys will be used as filenames where posts (values) will be rendered"
    c comparator COMPARATOR code "Sort by comparator function"
    p page       PAGE       str  "Collection result page path"]
   (let [pods      (wrap-pool (pod/pod-pool (boot/get-env)))
         tmp       (boot/tmp-dir!)
-        options   (merge +collection-defaults+ *opts*)]
+        options   (merge +collection-defaults+ *opts* (if-let [p (:page *opts*)]
+                                                        {:groupby (fn [_] p)}))]
     (cond (not (test/function? (:comparator options)))
               (u/fail "collection task :comparator option should be a function\n")
           (not (test/function? (:filterer options)))
               (u/fail "collection task :filterer option should be a function\n")
+          (and (:page options) (:groupby *opts*))
+              (u/warn "using the :page option will render any :groupby option setting effectless\n")
+          (not (ifn? (:groupby options)))
+              (u/fail "collection task :groupby option should implement IFn\n")
           (not (test/function? (:sortby options)))
               (u/fail "collection task :sortby option should be a function\n")
           :else
@@ -344,9 +351,11 @@
               (let [pod            (pods fileset)
                     files          (vals (perun/get-meta fileset))
                     filtered-files (filter (:filterer options) files)
-                    sorted-files   (vec (sort-by (:sortby options) (:comparator options) filtered-files))
-                    html           (render-in-pod pod renderer (perun/get-global-meta fileset) sorted-files)
-                    page-filepath  (perun/create-filepath (:out-dir options) page)]
-                (perun/create-file tmp page-filepath html)
-                (u/info (str "Render collection " page "\n"))
+                    grouped-files  (group-by (:groupby options) filtered-files)]
+                (doseq [[page files] grouped-files]
+                  (let [sorted-files  (vec (sort-by (:sortby options) (:comparator options) files))
+                        html          (render-in-pod pod renderer (perun/get-global-meta fileset) sorted-files)
+                        page-filepath (perun/create-filepath (:out-dir options) page)]
+                    (perun/create-file tmp page-filepath html)
+                    (u/info (str "Render collection " page "\n"))))
                 (commit fileset tmp))))))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -4,7 +4,6 @@
             [boot.pod :as pod]
             [boot.util :as u]
             [clojure.string :as string]
-            [clojure.test :as test]
             [clojure.edn :as edn]
             [io.perun.core :as perun]))
 
@@ -336,16 +335,16 @@
         tmp       (boot/tmp-dir!)
         options   (merge +collection-defaults+ *opts* (if-let [p (:page *opts*)]
                                                         {:groupby (fn [_] p)}))]
-    (cond (not (test/function? (:comparator options)))
+    (cond (not (fn? (:comparator options)))
               (u/fail "collection task :comparator option should be a function\n")
-          (not (test/function? (:filterer options)))
-              (u/fail "collection task :filterer option should be a function\n")
+          (not (ifn? (:filterer options)))
+              (u/fail "collection task :filterer option value should implement IFn\n")
           (and (:page options) (:groupby *opts*))
-              (u/warn "using the :page option will render any :groupby option setting effectless\n")
+              (u/fail "using the :page option will render any :groupby option setting effectless\n")
           (not (ifn? (:groupby options)))
-              (u/fail "collection task :groupby option should implement IFn\n")
-          (not (test/function? (:sortby options)))
-              (u/fail "collection task :sortby option should be a function\n")
+              (u/fail "collection task :groupby option value should implement IFn\n")
+          (not (ifn? (:sortby options)))
+              (u/fail "collection task :sortby option value should implement IFn\n")
           :else
             (boot/with-pre-wrap fileset
               (let [pod            (pods fileset)


### PR DESCRIPTION
Took me a while but I'm finally back at migrating my blog to perun.

I was playing with different approaches regarding pagination and this seems to be the most fruitful. 

Few thoughts:
- Shouldn't we use `ifn?` instead of `clojure.test/function` for things like `sortby` as keys could also be passed?
- maybe just fail if `:page` and `:groupby` are used to avoid potential confusion arising from not seeing warnings?
- alternative suggestions for `groupby` option docstring are welcome

Cheers
