### PR TITLE
preliminary version of new metadata structure

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -28,8 +28,7 @@
 
 (deftask dump-meta
   "Utility task to dump perun metadata via boot.util/info"
-  [r to-remove REMOVE [kw] "Keys to remove from metadata map values"
-   m map-fn    MAPFN  code "function to map over metadata items before printing"]
+  [m map-fn    MAPFN  code "function to map over metadata items before printing"]
   (boot/with-pre-wrap fileset
     (let [map-fn (or map-fn identity)]
       (prn (pr-str (map map-fn (perun/get-meta fileset)))))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -71,8 +71,8 @@
                           set)
             md-meta  (pod/with-call-in @pod
                        (io.perun.markdown/parse-markdown ~md-files ~options))
-            initial-metadata (perun/merge-meta (perun/get-meta fileset) @prev-meta)
-            final-metadata   (perun/merge-meta initial-metadata md-meta)
+            initial-metadata (perun/merge-meta* (perun/get-meta fileset) @prev-meta)
+            final-metadata   (perun/merge-meta* initial-metadata md-meta)
             final-metadata   (remove #(-> % :path removed?) final-metadata)
             fs-with-meta     (perun/set-meta fileset final-metadata)]
         (reset! prev-fs fileset)
@@ -198,7 +198,7 @@
       (u/dbug "Generated Permalinks:\n%s\n"
               (pr-str (map :permalink updated-files)))
       (u/info "Added permalinks to %s files\n" (count updated-files))
-      (perun/set-meta fileset updated-files))))
+      (perun/merge-meta fileset updated-files))))
 
 (deftask canonical-url
   "Adds :canonical-url key to files metadata.

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -376,10 +376,10 @@
                     files          (perun/get-meta fileset)
                     filtered-files (filter (:filterer options) files)
                     grouped-files  (group-by (:groupby options) filtered-files)]
-                (doseq [[page files] grouped-files]
-                  (let [sorted        (sort-by (:sortby options) (:comparator options) files)
+                (doseq [[page page-files] grouped-files]
+                  (u/info (str "Render collection " page "\n"))
+                  (let [sorted        (sort-by (:sortby options) (:comparator options) page-files)
                         html          (render-in-pod pod renderer (perun/get-global-meta fileset) sorted)
                         page-filepath (perun/create-filepath (:out-dir options) page)]
-                    (perun/create-file tmp page-filepath html)
-                    (u/info (str "Render collection " page "\n"))))
+                    (perun/create-file tmp page-filepath html)))
                 (commit fileset tmp))))))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -28,9 +28,11 @@
 
 (deftask dump-meta
   "Utility task to dump perun metadata via boot.util/info"
-  [r to-remove REMOVE [kw] "Keys to remove from metadata map values"]
+  [r to-remove REMOVE [kw] "Keys to remove from metadata map values"
+   m map-fn    MAPFN  code "function to map over metadata items before printing"]
   (boot/with-pre-wrap fileset
-    (prn (pr-str (map #(apply dissoc % to-remove) (perun/get-meta fileset))))
+    (let [map-fn (or map-fn identity)]
+      (prn (pr-str (map map-fn (perun/get-meta fileset)))))
     fileset))
 
 (deftask base

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -14,8 +14,11 @@
 (defn set-meta [fileset data]
   (vary-meta fileset assoc +meta-key+ (key-meta data)))
 
-(defn merge-meta [m1 m2]
+(defn merge-meta* [m1 m2]
   (vals (merge-with merge (key-meta m1) (key-meta m2))))
+
+(defn merge-meta [fileset data]
+  (set-meta fileset (merge-meta* (get-meta fileset) data)))
 
 (def +global-meta-key+ :io.perun.global)
 

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -15,8 +15,7 @@
   (vary-meta fileset assoc +meta-key+ (key-meta data)))
 
 (defn merge-meta [m1 m2]
-  (vals (merge-with merge (key-meta m1) (key-meta m2)))
-  #_(vary-meta fileset assoc +meta-key+ data))
+  (vals (merge-with merge (key-meta m1) (key-meta m2))))
 
 (def +global-meta-key+ :io.perun.global)
 

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -6,10 +6,17 @@
 (def +meta-key+ :io.perun)
 
 (defn get-meta [fileset]
-  (-> fileset meta +meta-key+))
+  (-> fileset meta +meta-key+ vals))
+
+(defn key-meta [data]
+  (into {} (for [d data] [(:path d) d])))
 
 (defn set-meta [fileset data]
-  (vary-meta fileset assoc +meta-key+ data))
+  (vary-meta fileset assoc +meta-key+ (key-meta data)))
+
+(defn merge-meta [m1 m2]
+  (vals (merge-with merge (key-meta m1) (key-meta m2)))
+  #_(vary-meta fileset assoc +meta-key+ data))
 
 (def +global-meta-key+ :io.perun.global)
 
@@ -49,43 +56,3 @@
   "Converts a url to filepath."
   [url]
   (apply create-filepath (string/split (relativize-url url) #"\/")))
-
-;;;; map for kv collections
-
-;; These are like ones in medley
-
-;; borrowed from https://github.com/metosin/potpuri/blob/master/src/potpuri/core.cljx#L203-L240
-
-(defn- editable? [coll]
-  (instance? clojure.lang.IEditableCollection coll))
-
-(defn- reduce-map [f coll]
-  (if (editable? coll)
-    (persistent! (reduce-kv (f assoc!) (transient (empty coll)) coll))
-    (reduce-kv (f assoc) (empty coll) coll)))
-
-(defn map-keys
-  "Map the keys of given associative collection using function."
-  [f coll]
-  (reduce-map (fn [xf] (fn [m k v]
-                         (xf m (f k) v)))
-              coll))
-
-(defn map-vals
-  "Map the values of given associative collection using function."
-  [f coll]
-  (reduce-map (fn [xf] (fn [m k v]
-                         (xf m k (f v))))
-              coll))
-
-(defn filter-keys
-  [pred coll]
-  (reduce-map (fn [xf] (fn [m k v]
-                         (if (pred k) (xf m k v) m)))
-              coll))
-
-(defn filter-vals
-  [pred coll]
-  (reduce-map (fn [xf] (fn [m k v]
-                         (if (pred v) (xf m k v) m)))
-              coll))

--- a/src/io/perun/gravatar.clj
+++ b/src/io/perun/gravatar.clj
@@ -3,12 +3,8 @@
             [io.perun.core :as perun]
             [gravatar      :as gr]))
 
-
 (defn find-gravatar [files source-prop target-prop]
-  (let [updated-files
-        (perun/map-vals
-          (fn [metadata]
-            (assoc metadata target-prop (gr/avatar-url (get metadata source-prop))))
-          files)]
+  (let [add-gravatar #(assoc % target-prop (gr/avatar-url (get % source-prop)))
+        updated-files (map add-gravatar files)]
     (u/info "Added gravatar to %s files\n" (count updated-files))
     updated-files))

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -88,10 +88,13 @@
   (let [file-content (slurp file)]
     ; .getName returns only the filename so this should work cross platform
     (u/info "Processing Markdown: %s\n" (.getName file))
-    [(.getName file) (merge (parse-file-metadata file-content)
-                            {:content (markdown-to-html file-content options)})]))
+    (merge (parse-file-metadata file-content)
+           {:content (markdown-to-html file-content options)})))
 
 (defn parse-markdown [markdown-files options]
-  (let [parsed-files (into {} (map #(-> % io/file (process-file options)) markdown-files))]
+  (let [->file       #(io/file (:dir %) (:path %))
+        parsed-files (into [] (for [f markdown-files]
+                                (merge {:path (:path f)}
+                                       (-> f ->file (process-file options)))))]
     (u/info "Parsed %s markdown files\n" (count markdown-files))
     parsed-files))

--- a/src/io/perun/ttr.clj
+++ b/src/io/perun/ttr.clj
@@ -5,10 +5,7 @@
 
 
 (defn calculate-ttr [files]
-  (let [updated-files
-        (perun/map-vals
-          (fn [metadata]
-            (assoc metadata :ttr (time-to-read/estimate-for-text (:content metadata))))
-          files)]
+  (let [add-ttr #(assoc % :ttr (time-to-read/estimate-for-text (:content %)))
+        updated-files (map add-ttr files)]
     (u/info "Added TTR to %s files\n" (count updated-files))
     updated-files))


### PR DESCRIPTION
Partly as discussed in #56 with some extras.

This changes the format of perun metadata from being a map to a list of maps. When using `io.perun.core/set-meta` and `io.perun.core/get-meta` these maps are transformed into one map using the values of the `:path` key as keys and if two metadata sets need to be merged this mechanism can be used via `io.perun.core/merge-meta`.

Not having to handle MapEntries every time simplifies metadata transformations and functions like `map-vals` are not as useful when you need both, the information in the key and in the value of a MapEntry.

I added a `base` task that establishes some initial structure. I'm not yet convinced this is useful in some way. Probably tasks that use the added `:filename` key should just look that up through the fileset (and then also add it to the metadata).
