### PR TITLE
Pass all pages to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ See documentation for each task to find all supported options for each plugin.
 (require '[hashobject.boot-s3 :refer :all])
 (require '[jeluard.boot-notify :refer [notify]])
 
-(defn renderer [global data] (:name data))
+(defn renderer [{global :meta posts :entries post :entry}] (:name post))
 
-(defn index-renderer [global files]
+(defn index-renderer [{global :meta files :entries}]
   (let [names (map :name files)]
     (clojure.string/join "\n" names)))
 

--- a/boot.properties
+++ b/boot.properties
@@ -1,4 +1,4 @@
 #https://github.com/boot-clj/boot
 #Sat Oct 03 13:45:25 PDT 2015
 BOOT_CLOJURE_VERSION=1.7.0
-BOOT_VERSION=2.3.0
+BOOT_VERSION=2.5.0-SNAPSHOT

--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (set-env!
   :source-paths #{"test"}
   :resource-paths #{"src" "resources"}
-  :dependencies '[[boot/core "2.4.2" :scope "provided"]
+  :dependencies '[[boot/core "2.5.0-SNAPSHOT" :scope "provided"]
                   [adzerk/bootlaces "0.1.13" :scope "test"]
                   [org.pegdown/pegdown "1.6.0" :scope "test"]
                   [circleci/clj-yaml "0.5.4" :scope "test"]

--- a/build.boot
+++ b/build.boot
@@ -14,7 +14,7 @@
 (require '[adzerk.bootlaces :refer :all])
 
 
-(def +version+ "0.2.0-SNAPSHOT")
+(def +version+ "0.2.1-SNAPSHOT")
 (bootlaces! +version+)
 
 (task-options!

--- a/example/boot.properties
+++ b/example/boot.properties
@@ -1,4 +1,4 @@
 #https://github.com/boot-clj/boot
 #Sat Oct 03 13:45:25 PDT 2015
 BOOT_CLOJURE_VERSION=1.7.0
-BOOT_VERSION=2.3.0
+BOOT_VERSION=2.5.0-SNAPSHOT

--- a/example/build.boot
+++ b/example/build.boot
@@ -1,7 +1,7 @@
 (set-env!
   :source-paths #{"src"}
   :resource-paths #{"resources"}
-  :dependencies '[[perun "0.2.0-SNAPSHOT"]
+  :dependencies '[[perun "0.2.1-SNAPSHOT"]
                   [hiccup "1.0.5"]
                   [pandeiro/boot-http "0.6.3-SNAPSHOT"]
                   [jeluard/boot-notify "0.1.2" :scope "test"]])

--- a/example/src/io/perun/example/index.clj
+++ b/example/src/io/perun/example/index.clj
@@ -3,9 +3,10 @@
         [hiccup.page :only (html5)]))
 
 
-(defn render [global-meta posts]
+(defn render [{global-meta :meta posts :entries}]
   (html5 {:lang "en" :itemtype "http://schema.org/Blog"}
     [:head
+      [:title (:site-title global-meta)]
       [:meta {:charset "utf-8"}]
       [:meta {:http-equiv "X-UA-Compatible" :content "IE=edge,chrome=1"}]
       [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0, user-scalable=no"}]]

--- a/example/src/io/perun/example/post.clj
+++ b/example/src/io/perun/example/post.clj
@@ -3,11 +3,15 @@
         [hiccup.page :only (html5)]))
 
 
-(defn render [global-meta post]
+(defn render [global-meta posts post]
   (html5 {:lang "en" :itemtype "http://schema.org/Blog"}
     [:head
       [:meta {:charset "utf-8"}]
       [:meta {:http-equiv "X-UA-Compatible" :content "IE=edge,chrome=1"}]
       [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0, user-scalable=no"}]     ]
     [:body
-        [:h1 (:name post)]]))
+        [:h1 (:name post)]
+        [:nav
+          [:ul
+            (for [page posts]
+              [:li (:name page)])]]]))

--- a/example/src/io/perun/example/post.clj
+++ b/example/src/io/perun/example/post.clj
@@ -3,9 +3,10 @@
         [hiccup.page :only (html5)]))
 
 
-(defn render [global-meta posts post]
+(defn render [{global-meta :meta posts :entries post :entry}]
   (html5 {:lang "en" :itemtype "http://schema.org/Blog"}
     [:head
+      [:title (str (:site-title global-meta) "|" (:name post))]
       [:meta {:charset "utf-8"}]
       [:meta {:http-equiv "X-UA-Compatible" :content "IE=edge,chrome=1"}]
       [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0, user-scalable=no"}]     ]

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -372,9 +372,10 @@
 
 (defn- render-in-pod [pod sym render-data]
   {:pre [(symbol? sym) (namespace sym)]}
+  (u/info "size %s" (count (prn-str render-data)))
   (pod/with-eval-in pod
     (require '~(symbol (namespace sym)))
-    ((resolve '~sym) ~render-data)))
+    ((resolve '~sym) ~(pod/send! render-data))))
 
 (def ^:private +render-defaults+
   {:out-dir  "public"

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -130,11 +130,10 @@
                              (io.perun.markdown/parse-markdown ~md-files ~options))
             initial-metadata (perun/merge-meta* (perun/get-meta fileset) @prev-meta)
             final-metadata   (perun/merge-meta* initial-metadata updated-files)
-            final-metadata   (remove #(-> % :path removed?) final-metadata)
-            fs-with-meta     (perun/set-meta fileset final-metadata)]
+            final-metadata   (remove #(-> % :path removed?) final-metadata)]
         (reset! prev-fs fileset)
         (reset! prev-meta final-metadata)
-        fs-with-meta))))
+        (perun/set-meta fileset final-metadata)))))
 
 (deftask global-metadata
   "Read global metadata from `perun.base.edn` or configured file.
@@ -144,15 +143,15 @@
    as the first argument to render functions."
   [n filename NAME str "filename to read global metadata from"]
   (boot/with-pre-wrap fileset
-    (perun/set-global-meta
-      fileset
-      (some->> fileset
-               boot/user-files
-               (boot/by-name [(or filename "perun.base.edn")])
-               first
-               boot/tmp-file
-               slurp
-               read-string))))
+    (let [global-meta
+            (some->> fileset
+                     boot/user-files
+                     (boot/by-name [(or filename "perun.base.edn")])
+                     first
+                     boot/tmp-file
+                     slurp
+                     read-string)]
+             (perun/set-global-meta fileset global-meta))))
 
 (def ^:private ttr-deps
   '[[time-to-read "0.1.0"]])
@@ -164,11 +163,10 @@
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
             updated-files (pod/with-call-in @pod
-                            (io.perun.ttr/calculate-ttr ~files))
-            fs-with-meta  (perun/set-meta fileset updated-files)]
+                            (io.perun.ttr/calculate-ttr ~files))]
         (u/dbug "Generated time-to-read:\n%s\n"
                 (pr-str (map :ttr updated-files)))
-        fs-with-meta))))
+        (perun/set-meta fileset updated-files)))))
 
 (deftask word-count
   "Count words in each file"
@@ -177,11 +175,10 @@
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
             updated-files (pod/with-call-in @pod
-                            (io.perun.word-count/count-words ~files))
-            fs-with-meta  (perun/set-meta fileset updated-files)]
+                            (io.perun.word-count/count-words ~files))]
         (u/dbug "Counted words:\n%s\n"
                 (pr-str (map :word-count updated-files)))
-        fs-with-meta))))
+        (perun/set-meta fileset updated-files)))))
 
 
 (def ^:private gravatar-deps
@@ -195,11 +192,10 @@
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
             updated-files (pod/with-call-in @pod
-                            (io.perun.gravatar/find-gravatar ~files ~source-key ~target-key))
-            fs-with-meta  (perun/set-meta fileset updated-files)]
-        (u/dbug "Find gravatars:\n%s\n"
+                            (io.perun.gravatar/find-gravatar ~files ~source-key ~target-key))]
+        (u/dbug "Found gravatars:\n%s\n"
                 (pr-str (map target-key updated-files)))
-      fs-with-meta))))
+      (perun/set-meta fileset updated-files)))))
 
 ;; Should be handled by more generic filterer options to other tasks
 (deftask draft
@@ -207,10 +203,9 @@
   []
   (boot/with-pre-wrap fileset
     (let [files         (perun/get-meta fileset)
-          updated-files (remove #(true? (:draft %)) files)
-          fs-with-meta  (perun/set-meta fileset updated-files)]
-      (u/info "Remove draft files. Remaining %s files\n" (count updated-files))
-      fs-with-meta)))
+          updated-files (remove #(true? (:draft %)) files)]
+      (u/info "Removed draft files. Remaining %s files\n" (count updated-files))
+      (perun/set-meta fileset updated-files))))
 
 (deftask build-date
   "Add :date-build attribute to each file metadata and also to the global meta"
@@ -221,11 +216,10 @@
           now             (java.util.Date.)
           updated-files   (map #(assoc % :date-build now) files)
           new-global-meta (assoc global-meta :date-build now)
-          updated-fs      (perun/set-meta fileset updated-files)
-          fs-with-meta    (perun/set-global-meta updated-fs new-global-meta)]
+          updated-fs      (perun/set-meta fileset updated-files)]
         (u/dbug "Added :date-build:\n%s\n"
                 (pr-str (map :date-build updated-files)))
-      fs-with-meta)))
+      (perun/set-global-meta updated-fs new-global-meta))))
 
 (defn ^:private default-slug-fn [filename]
   "Parses `slug` portion out of the filename in the format: YYYY-MM-DD-slug-title.ext
@@ -244,8 +238,7 @@
     (let [slug-fn       (or slug-fn default-slug-fn)
           files         (perun/get-meta fileset)
           updated-files (map #(assoc % :slug (-> % :filename slug-fn)) files)]
-      (u/dbug "Generated slugs:\n%s\n"
-              (pr-str (map :slug updated-files)))
+      (u/dbug "Generated slugs:\n%s\n" (pr-str (map :slug updated-files)))
       (u/info "Added slugs to %s files\n" (count updated-files))
       (perun/set-meta fileset updated-files))))
 
@@ -266,8 +259,7 @@
           files         (filter (:filterer options) (perun/get-meta fileset))
           assoc-perma   #(assoc % :permalink ((:permalink-fn options) %))
           updated-files (map assoc-perma files)]
-      (u/dbug "Generated permalinks:\n%s\n"
-              (pr-str (map :permalink updated-files)))
+      (u/dbug "Generated permalinks:\n%s\n" (pr-str (map :permalink updated-files)))
       (u/info "Added permalinks to %s files\n" (count updated-files))
       (perun/merge-meta fileset updated-files))))
 
@@ -476,9 +468,9 @@
                                             (perun/create-file tmp page-filepath html)
                                             new-entry)))
                                       grouped-files))
-                    updated-files (apply conj files new-files)
-                    fs-with-meta  (perun/set-meta fileset updated-files)]
-                  (commit fs-with-meta tmp))))))
+                    updated-files    (apply conj files new-files)
+                    updated-fileset  (perun/set-meta fileset updated-files)]
+                  (commit updated-fileset tmp))))))
 
 (deftask inject-scripts
   "Inject JavaScript scripts into html files.

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -370,23 +370,11 @@
         (reset! prev fileset)
         pod))))
 
-(defn- render-in-pod [pod sym global-meta files-meta file-meta]
+(defn- render-in-pod [pod sym render-data]
   {:pre [(symbol? sym) (namespace sym)]}
-  ;; Ensure passed seqs are vectors, otherwise lists/array-seqs etc
-  ;; wrapped in parentheses will be interpreted as function calls
-  (let [files-vector (if (sequential? files-meta) (vec files-meta) files-meta)]
-    (pod/with-eval-in pod
-      (require '~(symbol (namespace sym)))
-      ((resolve '~sym) ~global-meta ~files-vector ~file-meta))))
-
-(defn- collection-in-pod [pod sym global-meta files-meta]
-  {:pre [(symbol? sym) (namespace sym)]}
-  ;; Ensure passed seqs are vectors, otherwise lists/array-seqs etc
-  ;; wrapped in parentheses will be interpreted as function calls
-  (let [files-vector (if (sequential? files-meta) (vec files-meta) files-meta)]
-    (pod/with-eval-in pod
-      (require '~(symbol (namespace sym)))
-      ((resolve '~sym) ~global-meta ~files-vector))))
+  (pod/with-eval-in pod
+    (require '~(symbol (namespace sym)))
+    ((resolve '~sym) ~render-data)))
 
 (def ^:private +render-defaults+
   {:out-dir  "public"
@@ -411,7 +399,10 @@
         (u/info "Render pages %s\n" (count content-files))
         (doseq [{:keys [path] :as file} content-files]
           (u/dbug " - %s" path)
-          (let [html          (render-in-pod pod renderer (perun/get-global-meta fileset) content-files file)
+          (let [render-data   {:meta    (perun/get-global-meta fileset)
+                               :entries (vec content-files)
+                               :entry   file}
+                html          (render-in-pod pod renderer render-data)
                 page-filepath (perun/create-filepath
                                 (:out-dir options)
                                 ; If permalink ends in slash, append index.html as filename
@@ -467,7 +458,9 @@
                                         (do
                                           (u/info "Render collection %s\n" page)
                                           (let [sorted        (sort-by (:sortby options) (:comparator options) page-files)
-                                                html          (collection-in-pod pod renderer global-meta sorted)
+                                                render-data   {:meta    global-meta
+                                                               :entries (vec sorted)}
+                                                html          (render-in-pod pod renderer render-data)
                                                 page-filepath (perun/create-filepath (:out-dir options) page)
                                                 new-entry     {
                                                   :path page-filepath

--- a/src/io/perun/contrib/inject_scripts.clj
+++ b/src/io/perun/contrib/inject_scripts.clj
@@ -13,5 +13,5 @@
 (defn inject-scripts [scripts in-path out-path]
   (let [html (-> in-path io/file slurp)
         updated-html (inject html scripts)]
-    (u/info "Injecting JS scripts %s into %s\n" scripts in-path)
+    (u/info "Injected JS scripts %s into %s\n" scripts in-path)
     (spit (io/file out-path) updated-html)))

--- a/src/io/perun/contrib/inject_scripts.clj
+++ b/src/io/perun/contrib/inject_scripts.clj
@@ -9,7 +9,6 @@
     html
     scripts))
 
-
 (defn inject-scripts [scripts in-path out-path]
   (let [html (-> in-path io/file slurp)
         updated-html (inject html scripts)]

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -14,7 +14,9 @@
 (defn key-meta [data]
   (into {} (for [d data] [(:path d) d])))
 
-(defn set-meta [fileset data]
+(defn set-meta
+  "Update `+meta-key+` metadata for the fileset and return updates fileset"
+  [fileset data]
   (vary-meta fileset assoc +meta-key+ (key-meta data)))
 
 (defn merge-meta* [m1 m2]


### PR DESCRIPTION
So I changed signature of the render function that user needs to implement.
Instead of passing `global-meta` and `file-meta` we would have `global-meta`, `files-meta` and `file-meta`.
This is important because sometimes on the page you want to render navigation and to do that you need information about all files.
PR also includes minor documentation changes.
