### PR TITLE
Images task

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -91,7 +91,7 @@
           pod (create-pod images-resize-deps)
           files (->> fileset
                      boot/user-files
-                     (boot/by-ext ["png" "jpeg" "jpg"])
+                     (boot/by-ext perun/images-exts)
                      (map add-filedata))
           updated-files (pod/with-call-in @pod
                          (io.perun.contrib.images-resize/images-resize ~(.getPath tmp) ~files ~options))]
@@ -202,7 +202,10 @@
   []
   (boot/with-pre-wrap fileset
     (let  [files          (perun/get-meta fileset)
-           images         (filter :width files)
+           images         (filter
+                              (fn [file]
+                                (contains? perun/images-exts (perun/extension file)))
+                              files)
            groupped-files (group-by :parent-path images)
            assoc-images   (fn [file]
                              (if (not? (nil? (:content file)))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -196,6 +196,22 @@
         (perun/report-debug "gravatar" "found gravatars" (map target-key updated-files))
        (perun/set-meta fileset updated-files)))))
 
+
+(deftask images
+  "Assoc list of :images to the post"
+  []
+  (boot/with-pre-wrap fileset
+    (let  [files          (perun/get-meta fileset)
+           images         (filter :width files)
+           groupped-files (group-by :parent-path images)
+           assoc-images   (fn [file]
+                             (if (not? (nil? (:content file)))
+                               (assoc file :images (get groupped-files (:parent-path file)))
+                               file))
+           updated-files  (map assoc-images files)]
+      (perun/report-info "images" "add associated images to %s files" (count updated-files))
+      (perun/set-meta fileset updated-files))))
+
 ;; Should be handled by more generic filterer options to other tasks
 (deftask draft
   "Exclude draft files"

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -38,6 +38,8 @@
 (defn set-global-meta [fileset data]
   (vary-meta fileset assoc +global-meta-key+ data))
 
+(def images-exts #{"jpg" "svg" "png" "gif" "JPG" "SVG" "PNG" "GIF"})
+
 (defn report-info [task msg & args]
   (apply u/info
         (str


### PR DESCRIPTION
Extracted this plugin from my other experimental project.
Should be used with the following structure:
- create folder for each page
- put markdown file and images inside each folder
- after using markdown task and images task images data would be available under `:images` key on the post metadata

Not fully tested it. Need to create proper example
