### PR TITLE
Fix feed task options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ But if you want to make permalinks, generate sitemap and rss feed, hide unfinish
         (permalink)
         (render :renderer renderer)
         (sitemap :filename "sitemap.xml")
-        (rss :site-title "Hashobject" :site-description "Hashobject blog" :base-url "http://blog.hashobject.com")
-        (atom-feed :site-title "Hashobject" :site-description "Hashobject blog" :base-url "http://blog.hashobject.com")
+        (rss :title "Hashobject" :description "Hashobject blog" :link "http://blog.hashobject.com")
+        (atom-feed :title "Hashobject" :description "Hashobject blog" :link "http://blog.hashobject.com")
         (notify)))
 ```
 You can also chain this with standard boot tasks. E.x. if you want to upload generated files to Amazon S3 you might use
@@ -182,7 +182,7 @@ See documentation for each task to find all supported options for each plugin.
         (render :renderer renderer)
         (collection :renderer index-renderer :page "index.html")
         (sitemap :filename "sitemap.xml")
-        (rss :site-title "Hashobject" :site-description "Hashobject blog" :base-url "http://blog.hashobject.com")
+        (rss :title "Hashobject" :description "Hashobject blog" :link "http://blog.hashobject.com")
         (s3-sync)
         (notify)))
 ```

--- a/build.boot
+++ b/build.boot
@@ -15,7 +15,7 @@
 (require '[adzerk.bootlaces :refer :all])
 
 
-(def +version+ "0.3.0")
+(def +version+ "0.3.1")
 (bootlaces! +version+)
 
 (task-options!

--- a/examples/blog/build.boot
+++ b/examples/blog/build.boot
@@ -35,8 +35,8 @@
         (collection :renderer 'io.perun.example.index/render :page "index.html" :filterer identity)
         (inject-scripts :scripts #{"start.js"})
         (sitemap)
-        (rss :site-description "Hashobject blog")
-        (atom-feed  :site-title "Hashobject" :base-url "http://blog.hashobject.com")
+        (rss :description "Hashobject blog")
+        (atom-feed :title "Hashobject" :link "http://blog.hashobject.com")
         (notify)))
 
 (deftask dev

--- a/src/io/perun/atom.clj
+++ b/src/io/perun/atom.clj
@@ -12,22 +12,22 @@
 (defn iso-datetime [date]
   (tf/unparse (tf/formatters :date-time-no-ms) (tc/from-date date)))
 
-(defn generate-atom-str [posts {:keys [site-title site-description base-url filename]}]
+(defn generate-atom-str [posts {:keys [title description link filename]}]
   ; FIXME: title and link are required, Schema validation?
   (xml/emit-str
     (xml/sexp-as-element
       [:feed {:xmlns "http://www.w3.org/2005/Atom"}
-       [:title site-title]
-       (if  site-description [:subtitle  site-description])
-       [:link {:href (str base-url "/" filename) :rel "self"}]
-       [:link {:href base-url}]
+       [:title title]
+       (if description [:subtitle  description])
+       [:link {:href (str link "/" filename) :rel "self"}]
+       [:link {:href link}]
        [:updated (->> (take 10 posts)
                       (map updated)
                       (map iso-datetime)
                       sort
                       reverse
                       first)]
-       [:id base-url]
+       [:id link]
        (for [{:keys [permalink canonical-url content name author author-email] :as post} (take 10 posts)]
          ; FIXME: permalink is required
          [:entry

--- a/src/io/perun/rss.clj
+++ b/src/io/perun/rss.clj
@@ -12,14 +12,9 @@
      :author      (:author-email file)}))
 
 (defn generate-rss-str [files options]
-  (let [opts         (select-keys options [:site-title :site-description :base-url])
-        channel-opts (clojure.set/rename-keys
-                      opts
-                      {:site-title :title
-                       :site-description :description
-                       :base-url :link})
+  (let [opts         (select-keys options [:title :description :link])
         items        (rss-definitions (filter :name files))
-        rss-str      (apply rss-gen/channel-xml channel-opts items)]
+        rss-str      (apply rss-gen/channel-xml opts items)]
     rss-str))
 
 (defn generate-rss [tgt-path files options]


### PR DESCRIPTION
At some point, the option names passed to `rss` and `atom-feed` tasks
were changed, but the feed building code wasn't updated to expect the
new option names.
