### PR TITLE
feat(asciidoctor): basic asciidoc plugin

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -11,7 +11,8 @@
                   [gravatar "1.1.1" :scope "test"]
                   [clj-time "0.12.0" :scope "test"]
                   [mvxcvi/puget "1.0.0" :scope "test"]
-                  [com.novemberain/pantomime "2.8.0" :scope "test"]])
+                  [com.novemberain/pantomime "2.8.0" :scope "test"]
+                  [org.asciidoctor/asciidoctorj "1.5.4" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -147,10 +147,12 @@
     [circleci/clj-yaml "0.5.5"]])
 
 (def ^:private +asciidoctor-defaults+
-  {:gempath       ""
-   :libraries     ["asciidoctor-diagram"]
-   :header_footer false
-   :attributes    {:generator "perun"}})
+  {:gempath       ""                          ; no given gempath
+   :libraries     ["asciidoctor-diagram"]     ; asciidoctor-diagram incl.
+   :header_footer false                       ; no full HTML doc
+   :attributes    {:generator         "perun" ; context to document
+                   :backend           "html5" ; for HTML5 output
+                   :skip-front-matter ""}})   ; skip YAML frontmatter
 
 (deftask asciidoctor
   "Parse asciidoc files

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -153,7 +153,8 @@
    :attributes    {:generator         "perun" ; context to document
                    :backend           "html5" ; for HTML5 output
                    :skip-front-matter ""      ; skip YAML frontmatter
-                   :showtitle ""}})
+                   :showtitle         ""      ; include <h1> from header
+                   :imagesdir         "."}})  ; image dir relative to adoc file
 
 (deftask asciidoctor
   "Parse asciidoc files

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -142,6 +142,46 @@
         (reset! prev-meta final-metadata)
         (perun/set-meta fileset final-metadata)))))
 
+(def ^:private asciidoctor-deps
+  '[[org.asciidoctor/asciidoctorj "1.5.4"]
+    [circleci/clj-yaml "0.5.5"]])
+
+(deftask asciidoctor
+  "Parse asciidoc files
+
+   This task will look for files ending with `adoc` (preferred), `ad`, `asc`,
+   `adoc` or `asciidoc` and add a `:content` key to their metadata containing
+   the HTML resulting from processing asciidoc file's content"
+  [o options OPTS edn "options to be passed to the asciidoctor parser"]
+  (let [pod       (create-pod asciidoctor-deps)
+        prev-meta (atom {})
+        prev-fs   (atom nil)]
+    (boot/with-pre-wrap fileset
+      (let [ad-files (->> fileset
+                          (boot/fileset-diff @prev-fs)
+                          boot/user-files
+                          (boot/by-ext ["ad" "asc" "adoc" "asciidoc"])
+                          add-filedata)
+            ; process all removed asciidoc files
+            removed? (->> fileset
+                          (boot/fileset-removed @prev-fs)
+                          boot/user-files
+                          (boot/by-ext ["ad" "asc" "adoc" "asciidoc"])
+                          (map #(boot/tmp-path %))
+                          set)
+            updated-files (pod/with-call-in @pod
+                             (io.perun.contrib.asciidoctor/parse-asciidoc ~ad-files ~options))
+            initial-metadata (perun/merge-meta* (perun/get-meta fileset) @prev-meta)
+            ; Pure merge instead of `merge-with merge` (meta-meta).
+            ; This is because updated metadata should replace previous metadata to
+            ; correctly handle cases where a metadata key is removed from post metadata.
+            final-metadata   (vals (merge (perun/key-meta initial-metadata) (perun/key-meta updated-files)))
+            final-metadata   (remove #(-> % :path removed?) final-metadata)]
+        (reset! prev-fs fileset)
+        (reset! prev-meta final-metadata)
+        (perun/set-meta fileset final-metadata)))))
+;; TODO perhaps reuse the Asciidoctor container inside a pod, to prevent repeatedly re-initializing the JRuby container.
+
 (deftask global-metadata
   "Read global metadata from `perun.base.edn` or configured file.
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -147,9 +147,10 @@
     [circleci/clj-yaml "0.5.5"]])
 
 (def ^:private +asciidoctor-defaults+
-  {:gempath    ""
-   :libraries  '("asciidoctor-diagram")
-   :attributes {:generator "perun"}})
+  {:gempath       ""
+   :libraries     ["asciidoctor-diagram"]
+   :header_footer false
+   :attributes    {:generator "perun"}})
 
 (deftask asciidoctor
   "Parse asciidoc files

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -152,7 +152,8 @@
    :header_footer false                       ; no full HTML doc
    :attributes    {:generator         "perun" ; context to document
                    :backend           "html5" ; for HTML5 output
-                   :skip-front-matter ""}})   ; skip YAML frontmatter
+                   :skip-front-matter ""      ; skip YAML frontmatter
+                   :showtitle ""}})
 
 (deftask asciidoctor
   "Parse asciidoc files
@@ -163,7 +164,7 @@
    asciidoc file's content"
   [o options OPTS edn "options to be passed to the asciidoctor parser"]
 
-  (let [options   (merge +images-resize-defaults+ *opts*)
+  (let [options   (merge +asciidoctor-defaults+ *opts*)
         pod       (create-pod asciidoctor-deps)
         prev-meta (atom {})
         prev-fs   (atom nil)]
@@ -191,7 +192,7 @@
         (reset! prev-fs fileset)
         (reset! prev-meta final-metadata)
         (perun/set-meta fileset final-metadata)))))
-;; TODO perhaps reuse the Asciidoctor container inside a pod, to prevent repeatedly re-initializing the JRuby container.
+;; TODO Support task option syntax
 
 (deftask global-metadata
   "Read global metadata from `perun.base.edn` or configured file.

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -146,14 +146,22 @@
   '[[org.asciidoctor/asciidoctorj "1.5.4"]
     [circleci/clj-yaml "0.5.5"]])
 
+(def ^:private +asciidoctor-defaults+
+  {:gempath    ""
+   :libraries  '("asciidoctor-diagram")
+   :attributes {:generator "perun"}})
+
 (deftask asciidoctor
   "Parse asciidoc files
 
-   This task will look for files ending with `adoc` (preferred), `ad`, `asc`,
-   `adoc` or `asciidoc` and add a `:content` key to their metadata containing
-   the HTML resulting from processing asciidoc file's content"
+   This task will look for files ending with `adoc` (preferred),
+   `ad`, `asc`, `adoc` or `asciidoc` and add a `:content` key to
+   their metadata containing the HTML resulting from processing
+   asciidoc file's content"
   [o options OPTS edn "options to be passed to the asciidoctor parser"]
-  (let [pod       (create-pod asciidoctor-deps)
+
+  (let [options   (merge +images-resize-defaults+ *opts*)
+        pod       (create-pod asciidoctor-deps)
         prev-meta (atom {})
         prev-fs   (atom nil)]
     (boot/with-pre-wrap fileset
@@ -170,7 +178,7 @@
                           (map #(boot/tmp-path %))
                           set)
             updated-files (pod/with-call-in @pod
-                             (io.perun.contrib.asciidoctor/parse-asciidoc ~ad-files ~options))
+                             (io.perun.contrib.asciidoctor/parse-asciidoc ~ad-files ~(merge +asciidoctor-defaults+ options)))
             initial-metadata (perun/merge-meta* (perun/get-meta fileset) @prev-meta)
             ; Pure merge instead of `merge-with merge` (meta-meta).
             ; This is because updated metadata should replace previous metadata to

--- a/src/io/perun/contrib/asciidoctor.clj
+++ b/src/io/perun/contrib/asciidoctor.clj
@@ -5,39 +5,68 @@
             [clojure.string    :as str]
             [clj-yaml.core     :as yml]
             [io.perun.markdown :as md])
-  (:import [org.asciidoctor Asciidoctor Asciidoctor$Factory]
-           org.asciidoctor.internal.JRubyAsciidoctor))
+  (:import [org.asciidoctor Asciidoctor Asciidoctor$Factory]))
 
-(def adoc-container-defaults {:gempath   ""
-                              :libraries '("asciidoctor-diagram")})
+(defn keywords->names
+  "Converts a map with keywords to a map with named keys. Only handles the top
+   level of any nesting structure."
+  [m]
+  (reduce-kv #(assoc %1 (name %2) %3) {} m))
+
+(defn normalize-options
+  "Takes the options for the Asciidoctor parser and puts the in the format
+   appropriate for handling by the downstream functions. Mostly to better suit
+   the parsing by the AsciidoctorJ library."
+  [clj-opts]
+  (let [atr  (-> (:attributes clj-opts)
+                 (keywords->names)
+                 (java.util.HashMap.))
+        opts (assoc clj-opts :attributes atr)]
+    (keywords->names opts)))
+
 ;; TODO integrate all options and defaults into a single map, and expose to the perun.clj file
 
-(defn new-adoc-container [& {:keys [gempath libraries]}]
-  (let [defaults  adoc-container-defaults
-        gempath   (or gempath   (:gempath   defaults))
-        libraries (or libraries (:libraries defaults))]
+(defn new-adoc-container
+  "Creates a new AsciidoctorJ (JRuby) container, based on the normalized options
+   provided."
+  [n-opts]
+  (let [libraries (get n-opts "libraries")]
     ; (AsciidoctorContainer. (Asciidoctor$Factory/create) gempath libraries)))
-    (Asciidoctor$Factory/create gempath)))
+    (Asciidoctor$Factory/create (str (get n-opts "gempath")))))
 ;; TODO add desired libraries
 
-(defn parse-file-metadata [file-content]
+(defn parse-file-metadata
+  "Read the file-content and derive relevant metadata for use in other Perun
+   tasks."
+  [file-content]
   (md/parse-file-metadata file-content))
 ;; TODO include asciidoctor based metadata including attributes
 
-(defn asciidoc-to-html [file-content options]
-  (let [container (new-adoc-container)
-        opts {"backend" "html5"}]
-    (.convert container file-content opts)))
+(defn asciidoc-to-html
+  "Converts a given string of asciidoc into HTML. The normalized options that
+   can be provided, influence the behavior of the conversion."
+  [file-content n-opts]
+  (let [container (new-adoc-container n-opts)
+        options   (-> (select-keys ["header_footer" "attributes"] n-opts)
+                      (assoc "backend" "html5"))]
+    (.convert container (md/remove-metadata file-content) options)))
 ;; TODO incorporate options into container creation
 
-(defn process-file [file options]
+(defn process-file
+  "Parses the content of a single file and associates the available metadata to
+   the resulting html string. The HTML conversion is dispatched."
+  [file options]
   (perun/report-debug "asciidoctor" "processing asciidoc" (:filename file))
   (let [file-content (-> file :full-path io/file slurp)
-        ad-metadata (parse-file-metadata file-content)
-        html (asciidoc-to-html file-content options)]
+        ad-metadata  (parse-file-metadata file-content)
+        n-opts       (normalize-options options)
+        html         (asciidoc-to-html file-content n-opts)]
     (merge ad-metadata {:content html} file)))
 
-(defn parse-asciidoc [asciidoc-files options]
+(defn parse-asciidoc
+  "Responsible for parsing all provided asciidoc files. The actual parsing is
+   dispatched."
+  [asciidoc-files options]
   (let [updated-files (doall (map #(process-file % options) asciidoc-files))]
     (perun/report-info "asciidoctor" "parsed %s asciidoc files" (count asciidoc-files))
     updated-files))

--- a/src/io/perun/contrib/asciidoctor.clj
+++ b/src/io/perun/contrib/asciidoctor.clj
@@ -1,3 +1,12 @@
+;   Copyright (c) 2016 Nico Rikken nico@nicorikken.eu
+;   All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file LICENSE at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
 (ns io.perun.contrib.asciidoctor
   "AsciidoctorJ based converter from Asciidoc to HTML."
   (:require [io.perun.core     :as perun]

--- a/src/io/perun/contrib/asciidoctor.clj
+++ b/src/io/perun/contrib/asciidoctor.clj
@@ -1,0 +1,43 @@
+(ns io.perun.contrib.asciidoctor
+  "AsciidoctorJ based converter from Asciidoc to HTML"
+  (:require [io.perun.core     :as perun]
+            [clojure.java.io   :as io]
+            [clojure.string    :as str]
+            [clj-yaml.core     :as yml]
+            [io.perun.markdown :as md])
+  (:import [org.asciidoctor Asciidoctor Asciidoctor$Factory]
+           org.asciidoctor.internal.JRubyAsciidoctor))
+
+(def adoc-container-defaults {:gempath   ""
+                              :libraries '("asciidoctor-diagram")})
+;; TODO integrate all options and defaults into a single map, and expose to the perun.clj file
+
+(defn new-adoc-container [& {:keys [gempath libraries]}]
+  (let [defaults  adoc-container-defaults
+        gempath   (or gempath   (:gempath   defaults))
+        libraries (or libraries (:libraries defaults))]
+    ; (AsciidoctorContainer. (Asciidoctor$Factory/create) gempath libraries)))
+    (Asciidoctor$Factory/create gempath)))
+;; TODO add desired libraries
+
+(defn parse-file-metadata [file-content]
+  (md/parse-file-metadata file-content))
+;; TODO include asciidoctor based metadata including attributes
+
+(defn asciidoc-to-html [file-content options]
+  (let [container (new-adoc-container)
+        opts {"backend" "html5"}]
+    (.convert container file-content opts)))
+;; TODO incorporate options into container creation
+
+(defn process-file [file options]
+  (perun/report-debug "asciidoctor" "processing asciidoc" (:filename file))
+  (let [file-content (-> file :full-path io/file slurp)
+        ad-metadata (parse-file-metadata file-content)
+        html (asciidoc-to-html file-content options)]
+    (merge ad-metadata {:content html} file)))
+
+(defn parse-asciidoc [asciidoc-files options]
+  (let [updated-files (doall (map #(process-file % options) asciidoc-files))]
+    (perun/report-info "asciidoctor" "parsed %s asciidoc files" (count asciidoc-files))
+    updated-files))

--- a/test/io/perun/contrib/asciidoctor_test.clj
+++ b/test/io/perun/contrib/asciidoctor_test.clj
@@ -65,12 +65,13 @@ I Zeus would like to describe how the god Perun relates to my image.
    :basebackend-html "",
    :basebackend-html-doctype-article "",
    :caution-caption "Caution",
-   :docdate "2016-09-16",
+  ;  :docdate "2016-09-16",
   ;  :docdatetime "2016-09-16 08:31:58 CEST",
    :docdir "",
   ;  :doctime "08:31:58 CEST",
    :doctype "article",
    :doctype-article "",
+   :draft nil, ;; from frontmatter
    :embedded "",
    :example-caption "Example",
    :figure-caption "Figure",
@@ -88,8 +89,10 @@ I Zeus would like to describe how the god Perun relates to my image.
   ;  :localtime "08:31:58 CEST",
    :manname-title "NAME",
    :max-include-depth 64,
+   :name "in my own image" ;; from frontmatter
    :note-caption "Note",
    :notitle "",
+   :original true, ;; from frontmatter
    :outfilesuffix ".html",
    :prewrap "",
    :safe-mode-level 20,

--- a/test/io/perun/contrib/asciidoctor_test.clj
+++ b/test/io/perun/contrib/asciidoctor_test.clj
@@ -1,7 +1,8 @@
 (ns io.perun.contrib.asciidoctor-test
   (:require [clojure.test :refer :all]
             [clojure.set :as s]
-            [io.perun.contrib.asciidoctor :refer :all]))
+            [io.perun.contrib.asciidoctor :refer :all]
+            [io.perun]))
 
 (def sample-adoc "
 ---
@@ -9,9 +10,11 @@ draft:
 name: in my own image
 ---
 = In my own image: Perun
-:author: Zeus zeus@thunderdome.olympus
+:author: Zeus
+:email: zeus@thunderdome.olympus
 :revdate: 02-08-907
 :toc:
+:description: Some posts are close to your heart...
 
 I Zeus would like to describe how the god Perun relates to my image.
 
@@ -58,6 +61,11 @@ I Zeus would like to describe how the god Perun relates to my image.
    :asciidoctor-version "1.5.4",
    :attribute-missing "skip",
    :attribute-undefined "drop-line",
+   :author "Zeus",
+   :author-email "zeus@thunderdome.olympus",
+   :authorcount 1,
+   :authorinitials "Z",
+   :authors "Zeus",
    :backend "html5",
    :backend-html5 "",
    :backend-html5-doctype-article "",
@@ -65,18 +73,24 @@ I Zeus would like to describe how the god Perun relates to my image.
    :basebackend-html "",
    :basebackend-html-doctype-article "",
    :caution-caption "Caution",
+  ;  :date-build "2016-09-16",
+  ;  :date-modified "2016-09-16"
+   :description "Some posts are close to your heart..."
   ;  :docdate "2016-09-16",
   ;  :docdatetime "2016-09-16 08:31:58 CEST",
    :docdir "",
   ;  :doctime "08:31:58 CEST",
+   :doctitle "In my own image: Perun"
    :doctype "article",
    :doctype-article "",
    :draft nil, ;; from frontmatter
+   :email "zeus@thunderdome.olympus"
    :embedded "",
    :example-caption "Example",
    :figure-caption "Figure",
    :filetype "html",
    :filetype-html "",
+   :firstname "Zeus"
    :generator "perun",
    :htmlsyntax "html",
    :iconfont-remote "",
@@ -89,20 +103,23 @@ I Zeus would like to describe how the god Perun relates to my image.
   ;  :localtime "08:31:58 CEST",
    :manname-title "NAME",
    :max-include-depth 64,
-   :name "in my own image" ;; from frontmatter
+   :name "In my own image: Perun" ;; frontmatter overwritten by doc
    :note-caption "Note",
    :notitle "",
    :original true, ;; from frontmatter
    :outfilesuffix ".html",
    :prewrap "",
+   :revdate "02-08-907"
    :safe-mode-level 20,
    :safe-mode-name "secure",
    :safe-mode-secure "",
+   :skip-front-matter ""
    :sectids "",
    :stylesdir ".",
    :stylesheet "",
    :table-caption "Table",
    :tip-caption "Tip",
+   :toc ""
    :toc-placement "auto",
    :toc-title "Table of Contents",
    :untitled-label "Untitled",
@@ -114,7 +131,7 @@ I Zeus would like to describe how the god Perun relates to my image.
 (def diagram-sample "
 = The way Perun does
 
-[plantuml, lighting-direction]
+[plantuml, lightning-direction]
 ....
 Branch --|> Velves
 ....
@@ -122,16 +139,12 @@ Branch --|> Velves
 
 (def expected-diagram-html "<div class=\"imageblock\">
 <div class=\"content\">
-<img src=\"lighting-direction.png\" alt=\"lighting direction\" width=\"88\" height=\"175\">
+<img src=\"lightning-direction.png\" alt=\"lightning direction\" width=\"88\" height=\"175\">
 </div>
 </div>")
 
-(def +asciidoctor-defaults+
-  {:gempath    ""
-   :libraries  ["asciidoctor-diagram"]
-   :attributes {:generator "perun"}})
-
-(def n-opts (normalize-options +asciidoctor-defaults+))
+(def n-opts (normalize-options @#'io.perun/+asciidoctor-defaults+))
+; deref the private defintion var to circument the private-ness
 
 (def container (new-adoc-container n-opts))
 

--- a/test/io/perun/contrib/asciidoctor_test.clj
+++ b/test/io/perun/contrib/asciidoctor_test.clj
@@ -1,5 +1,6 @@
 (ns io.perun.contrib.asciidoctor-test
   (:require [clojure.test :refer :all]
+            [clojure.set :as s]
             [io.perun.contrib.asciidoctor :refer :all]))
 
 (def sample-adoc "
@@ -52,9 +53,60 @@ I Zeus would like to describe how the god Perun relates to my image.
 </div>")
 
 (def expected-meta
-  {:draft nil
-   :name "in my own image"
-   :original true})
+  {:appendix-caption "Appendix",
+   :asciidoctor "",
+   :asciidoctor-version "1.5.4",
+   :attribute-missing "skip",
+   :attribute-undefined "drop-line",
+   :backend "html5",
+   :backend-html5 "",
+   :backend-html5-doctype-article "",
+   :basebackend "html",
+   :basebackend-html "",
+   :basebackend-html-doctype-article "",
+   :caution-caption "Caution",
+   :docdate "2016-09-16",
+  ;  :docdatetime "2016-09-16 08:31:58 CEST",
+   :docdir "",
+  ;  :doctime "08:31:58 CEST",
+   :doctype "article",
+   :doctype-article "",
+   :embedded "",
+   :example-caption "Example",
+   :figure-caption "Figure",
+   :filetype "html",
+   :filetype-html "",
+   :generator "perun",
+   :htmlsyntax "html",
+   :iconfont-remote "",
+   :iconsdir "./images/icons",
+   :important-caption "Important",
+   :last-update-label "Last updated",
+   :linkcss "",
+  ;  :localdate "2016-09-16",
+  ;  :localdatetime "2016-09-16 08:31:58 CEST",
+  ;  :localtime "08:31:58 CEST",
+   :manname-title "NAME",
+   :max-include-depth 64,
+   :note-caption "Note",
+   :notitle "",
+   :outfilesuffix ".html",
+   :prewrap "",
+   :safe-mode-level 20,
+   :safe-mode-name "secure",
+   :safe-mode-secure "",
+   :sectids "",
+   :stylesdir ".",
+   :stylesheet "",
+   :table-caption "Table",
+   :tip-caption "Tip",
+   :toc-placement "auto",
+   :toc-title "Table of Contents",
+   :untitled-label "Untitled",
+   :user-home ".",
+   :version-label "Version",
+   :warning-caption "Warning",
+   :webfonts ""})
 
 (def diagram-sample "
 = The way Perun does
@@ -76,17 +128,21 @@ Branch --|> Velves
    :libraries  ["asciidoctor-diagram"]
    :attributes {:generator "perun"}})
 
+(def n-opts (normalize-options +asciidoctor-defaults+))
+
+(def container (new-adoc-container n-opts))
+
 (deftest test-asciidoc-to-html
   "Test the `asciidoc-to-html` function on its actual conversion."
-  (let [rendered (asciidoc-to-html sample-adoc (normalize-options +asciidoctor-defaults+))]
+  (let [rendered (asciidoc-to-html container sample-adoc n-opts)]
     (is (= expected-html rendered))))
 
 (deftest test-parse-file-metadata
   "Test the metadata extraction by `parse-file-metadata`."
-  (let [metadata (parse-file-metadata sample-adoc)]
-    (is (= expected-meta metadata))))
+  (let [metadata (parse-file-metadata container sample-adoc n-opts)]
+    (is (s/subset? (into #{} expected-meta) (into #{} metadata)))))
 
 (deftest convert-with-asciidoctor-diagram
   "Test the handling by the `asciidoctor-diagram` library for built-in images"
-  (let [rendered (asciidoc-to-html diagram-sample (normalize-options +asciidoctor-defaults+))]
+  (let [rendered (asciidoc-to-html container diagram-sample n-opts)]
     (is (= expected-diagram-html rendered))))

--- a/test/io/perun/contrib/asciidoctor_test.clj
+++ b/test/io/perun/contrib/asciidoctor_test.clj
@@ -32,7 +32,8 @@ I Zeus would like to describe how the god Perun relates to my image.
 ----
 ")
 
-(def expected-html "<div class=\"paragraph\">
+(def expected-html "<h1>In my own image: Perun</h1>
+<div class=\"paragraph\">
 <p>I Zeus would like to describe how the god Perun relates to my image.</p>
 </div>
 <div class=\"quoteblock\">
@@ -137,7 +138,8 @@ Branch --|> Velves
 ....
 ")
 
-(def expected-diagram-html "<div class=\"imageblock\">
+(def expected-diagram-html "<h1>The way Perun does</h1>
+<div class=\"imageblock\">
 <div class=\"content\">
 <img src=\"lightning-direction.png\" alt=\"lightning direction\" width=\"88\" height=\"175\">
 </div>

--- a/test/io/perun/contrib/asciidoctor_test.clj
+++ b/test/io/perun/contrib/asciidoctor_test.clj
@@ -1,0 +1,72 @@
+(ns io.perun.contrib.asciidoctor-test
+  (:require [clojure.test :refer :all]
+            [io.perun.contrib.asciidoctor :refer :all]))
+
+(def sample-adoc "
+---
+draft:
+name: in my own image
+---
+= In my own image: Perun
+:author: Zeus zeus@thunderdome.olympus
+:revdate: 02-08-907
+:toc:
+
+I Zeus would like to describe how the god Perun relates to my image.
+
+[quote, Perun, Having struck Veles]
+\"Well, there is your place, remain there!\"
+
+.No power more godlike then the Clojure power of Perun
+[source, clojure]
+----
+(deftask build
+  \"Build blog.\"
+  []
+  (comp (asciidoctor)
+        (render :renderer renderer)))
+----
+")
+
+(def expected-html "<div class=\"paragraph\">
+<p>I Zeus would like to describe how the god Perun relates to my image.</p>
+</div>
+<div class=\"quoteblock\">
+<blockquote>
+\"Well, there is your place, remain there!\"
+</blockquote>
+<div class=\"attribution\">
+&#8212; Perun<br>
+<cite>Having struck Veles</cite>
+</div>
+</div>
+<div class=\"listingblock\">
+<div class=\"title\">No power more godlike then the Clojure power of Perun</div>
+<div class=\"content\">
+<pre class=\"highlight\"><code class=\"language-clojure\" data-lang=\"clojure\">(deftask build
+  \"Build blog.\"
+  []
+  (comp (asciidoctor)
+        (render :renderer renderer)))</code></pre>
+</div>
+</div>")
+
+(def expected-meta
+  {:draft nil
+   :name "in my own image"
+   :original true})
+
+(def +asciidoctor-defaults+
+  {:gempath    ""
+   :libraries  '("asciidoctor-diagram")
+   :attributes {:generator "perun"}})
+
+(deftest test-asciidoc-to-html
+  "Test the `asciidoc-to-html` function on its actual conversion."
+  (let [rendered (asciidoc-to-html sample-adoc (normalize-options +asciidoctor-defaults+))]
+    (is (= expected-html rendered))))
+
+(deftest test-parse-file-metadata
+  "Test the metadata extraction by `parse-file-metadata`."
+  (let [metadata (parse-file-metadata sample-adoc)]
+    (is (= expected-meta metadata))))

--- a/test/io/perun/contrib/asciidoctor_test.clj
+++ b/test/io/perun/contrib/asciidoctor_test.clj
@@ -56,9 +56,24 @@ I Zeus would like to describe how the god Perun relates to my image.
    :name "in my own image"
    :original true})
 
+(def diagram-sample "
+= The way Perun does
+
+[plantuml, lighting-direction]
+....
+Branch --|> Velves
+....
+")
+
+(def expected-diagram-html "<div class=\"imageblock\">
+<div class=\"content\">
+<img src=\"lighting-direction.png\" alt=\"lighting direction\" width=\"88\" height=\"175\">
+</div>
+</div>")
+
 (def +asciidoctor-defaults+
   {:gempath    ""
-   :libraries  '("asciidoctor-diagram")
+   :libraries  ["asciidoctor-diagram"]
    :attributes {:generator "perun"}})
 
 (deftest test-asciidoc-to-html
@@ -70,3 +85,8 @@ I Zeus would like to describe how the god Perun relates to my image.
   "Test the metadata extraction by `parse-file-metadata`."
   (let [metadata (parse-file-metadata sample-adoc)]
     (is (= expected-meta metadata))))
+
+(deftest convert-with-asciidoctor-diagram
+  "Test the handling by the `asciidoctor-diagram` library for built-in images"
+  (let [rendered (asciidoc-to-html diagram-sample (normalize-options +asciidoctor-defaults+))]
+    (is (= expected-diagram-html rendered))))


### PR DESCRIPTION
The asciidoc plugin uses AsciidoctorJ from the Asciidoctor project
to bring Asciidoc rendering to Perun.
This ticket is related to issue 49 on GitHub:
https://github.com/hashobject/perun/issues/49

**Left to do:**
- [x] Enable AsciidoctorJ libraries (like `asciidoctor-diagram`). In particular, how to handle the resulting image files? **Help desired!** _Images are now generated on root, will have to be handled properly_
- [x] Forward already available metadata to the document. _Metadata from the options is now forwarded_
- [x] Read metadata from the document, apart from the YAML
- [x] Link AsciidoctorJ containers to a pod for improved performance. **Help desired!** _Eventually linked to the fileset_
- [ ] Get image generation by `asciidoctor-diagram` handled properly, to make sure they end up in the end result, and at the right place. **Help desired!**
- [x] Change the metadata keywords for compatibility with the rest of Perun
- [x] Have the defaults generate HTML similar to the Markdown HTML (which headers and H1's included).
- [ ] Expand readme with info on the Asciidoctor support and how to use it.
