### PR TITLE
Insert inline js at body end instead of header end

### DIFF
--- a/src/io/perun/contrib/inject_scripts.clj
+++ b/src/io/perun/contrib/inject_scripts.clj
@@ -4,7 +4,7 @@
 
 (defn inject [html scripts]
   (reduce
-    #(.replaceFirst %1 "</head>" (format "<script>%s</script></head>" %2))
+    #(.replaceFirst %1 "</body>" (format "<script>%s</script></body>" %2))
     html
     scripts))
 


### PR DESCRIPTION
It's best practise for inline js, minimizes render blocking.
