### PR TITLE
Use tools namespace to reload changed clojure ns instead of pod pools

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -11,7 +11,8 @@
                   [gravatar "1.1.1" :scope "test"]
                   [clj-time "0.12.0" :scope "test"]
                   [mvxcvi/puget "1.0.0" :scope "test"]
-                  [com.novemberain/pantomime "2.8.0" :scope "test"]])
+                  [com.novemberain/pantomime "2.8.0" :scope "test"]
+                  [org.clojure/tools.namespace "0.3.0-alpha3" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -454,9 +454,6 @@
   (let [tmp       (boot/tmp-dir!)
         options   (merge +collection-defaults+ *opts* (if-let [p (:page *opts*)]
                                                         {:groupby (fn [_] p)}))]
-    (pod/with-call-in @render-pod
-      (io.perun.render/update!))
-
     (cond (not (fn? (:comparator options)))
           (u/fail "collection task :comparator option should implement IFn\n")
           (not (ifn? (:filterer options)))
@@ -469,6 +466,9 @@
           (u/fail "collection task :sortby option value should implement IFn\n")
           :else
             (boot/with-pre-wrap fileset
+              (pod/with-call-in @render-pod
+                (io.perun.render/update!))
+
               (let [files          (perun/get-meta fileset)
                     filtered-files (filter (:filterer options) files)
                     grouped-files  (group-by (:groupby options) filtered-files)

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -363,20 +363,6 @@
           (io.perun.atom/generate-atom ~(.getPath tmp) ~files ~(dissoc options :filterer)))
         (commit fileset tmp)))))
 
-(defn- wrap-pool [pool]
-  (let [prev (atom nil)]
-    (fn [fileset]
-      ; Do not refresh on the first run
-      (let [pod (if (and @prev
-                         (seq (->> fileset
-                                   (boot/fileset-diff @prev)
-                                   boot/input-files
-                                   (boot/by-ext ["clj" "cljc"]))))
-                  (pool :refresh)
-                  (pool))]
-        (reset! prev fileset)
-        pod))))
-
 (defn- assert-renderer [sym]
   (assert (and (symbol? sym) (namespace sym))
           "Renderer must be a fully qualified symbol, i.e. 'my.ns/fun"))
@@ -390,6 +376,11 @@
 (def ^:private +render-defaults+
   {:out-dir  "public"
    :filterer :content})
+
+(def ^:private render-deps
+  '[[org.clojure/tools.namespace "0.3.0-alpha3"]])
+
+(def render-pod (delay (create-pod' render-deps)))
 
 (deftask render
   "Render individual pages for entries in perun data.
@@ -410,17 +401,18 @@
   [o out-dir  OUTDIR   str  "the output directory (default: \"public\")"
    _ filterer FILTER   code "predicate to use for selecting entries (default: `:content`)"
    r renderer RENDERER sym  "page renderer (fully qualified symbol which resolves to a function)"]
-  (let [pods    (wrap-pool (pod/pod-pool (boot/get-env)))
-        tmp     (boot/tmp-dir!)
+  (let [tmp     (boot/tmp-dir!)
         options (merge +render-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [pod   (pods fileset)
-            files (filter (:filterer options) (perun/get-meta fileset))]
+      (let [files (filter (:filterer options) (perun/get-meta fileset))]
+        (pod/with-call-in @render-pod
+          (io.perun.render/update!))
+
         (doseq [{:keys [path] :as file} files]
           (let [render-data   {:meta    (perun/get-global-meta fileset)
                                :entries (vec files)
                                :entry   file}
-                html          (render-in-pod pod renderer render-data)
+                html          (render-in-pod @render-pod renderer render-data)
                 page-filepath (perun/create-filepath
                                 (:out-dir options)
                                 ; If permalink ends in slash, append index.html as filename
@@ -459,10 +451,12 @@
    g groupby    GROUPBY    code "group posts by function, keys are filenames, values are to-be-rendered entries"
    c comparator COMPARATOR code "sort by comparator function"
    p page       PAGE       str  "collection result page path"]
-  (let [pods      (wrap-pool (pod/pod-pool (boot/get-env)))
-        tmp       (boot/tmp-dir!)
+  (let [tmp       (boot/tmp-dir!)
         options   (merge +collection-defaults+ *opts* (if-let [p (:page *opts*)]
                                                         {:groupby (fn [_] p)}))]
+    (pod/with-call-in @render-pod
+      (io.perun.render/update!))
+
     (cond (not (fn? (:comparator options)))
           (u/fail "collection task :comparator option should implement IFn\n")
           (not (ifn? (:filterer options)))
@@ -475,8 +469,7 @@
           (u/fail "collection task :sortby option value should implement IFn\n")
           :else
             (boot/with-pre-wrap fileset
-              (let [pod            (pods fileset)
-                    files          (perun/get-meta fileset)
+              (let [files          (perun/get-meta fileset)
                     filtered-files (filter (:filterer options) files)
                     grouped-files  (group-by (:groupby options) filtered-files)
                     global-meta    (perun/get-global-meta fileset)
@@ -487,7 +480,7 @@
                                           (let [sorted        (sort-by (:sortby options) (:comparator options) page-files)
                                                 render-data   {:meta    global-meta
                                                                :entries (vec sorted)}
-                                                html          (render-in-pod pod renderer render-data)
+                                                html          (render-in-pod @render-pod renderer render-data)
                                                 page-filepath (perun/create-filepath (:out-dir options) page)
                                                 new-entry     {:path page-filepath
                                                                :canonical-url (str (:base-url global-meta) page)

--- a/src/io/perun/render.clj
+++ b/src/io/perun/render.clj
@@ -14,6 +14,9 @@
                    (util/dbug "Scan directories: %s\n" (pr-str (:directories pod/env)))
                    (dir/scan-dirs (or tracker (track/tracker)) (:directories pod/env))))
 
+  ;; Only reload namespaces which are already loaded
+  (swap! tracker (fn [tracker] (update tracker ::track/load (fn [load] (filter find-ns load)))))
+
   (let [changed-ns (::track/load @tracker)]
 
     (util/dbug "Unload: %s\n" (pr-str (::track/unload @tracker)))

--- a/src/io/perun/render.clj
+++ b/src/io/perun/render.clj
@@ -1,0 +1,31 @@
+(ns io.perun.render
+  (:require [boot.pod :as pod]
+            [boot.util :as util]
+            [clojure.string :as string]
+            [clojure.java.io :as io]
+            [clojure.tools.namespace.dir :as dir]
+            [clojure.tools.namespace.track :as track]
+            [clojure.tools.namespace.reload :as reload]))
+
+(def tracker (atom nil))
+
+(defn update! []
+  (swap! tracker (fn [tracker]
+                   (util/dbug "Scan directories: %s\n" (pr-str (:directories pod/env)))
+                   (dir/scan-dirs (or tracker (track/tracker)) (:directories pod/env))))
+
+  (let [changed-ns (::track/load @tracker)]
+
+    (util/dbug "Unload: %s\n" (pr-str (::track/unload @tracker)))
+    (util/dbug "Load: %s\n" (pr-str (::track/load @tracker)))
+
+    (swap! tracker reload/track-reload)
+
+    (try
+      (when (::reload/error @tracker)
+        (util/fail "Error reloading: %s\n" (name (::reload/error-ns @tracker)))
+        (throw (::reload/error @tracker)))
+      (catch java.io.FileNotFoundException e
+        (util/info "Reseting tracker due to file not found exception, all namespaces will be reloaded next time.\n")
+        (reset! tracker (track/tracker))
+        (throw e)))))


### PR DESCRIPTION
# Reasoning
- Current pod pool implementation is slow, after change to any clj file, render takes 15 seconds
- Each task has it's own pod pool -> 2 render tasks and 3 collection tasks -> 5 pod pools.
  Each pod pool is refreshed when a clj file changes, this is done sequentially so each render task adds to the execution time.
- If only single pod pool would be used recompilation would probably take only 3 seconds (but even this is too slow for me).
# With tools namespace
- Single pod for all render tasks (not sure if this can cause problems?)
- Any render task uses c.t.n to reload change clojure ns (and unload deleted ns etc.), usually no-op for all but the first task.
- Recompilation in 0.2 sec
