### PR TITLE
Pluggable parsing

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -11,7 +11,8 @@
                   [gravatar "1.1.1" :scope "test"]
                   [clj-time "0.12.0" :scope "test"]
                   [mvxcvi/puget "1.0.0" :scope "test"]
-                  [com.novemberain/pantomime "2.8.0" :scope "test"]])
+                  [com.novemberain/pantomime "2.8.0" :scope "test"]
+                  [org.asciidoctor/asciidoctorj "1.5.4.1" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -103,7 +103,14 @@
       (perun/set-meta fileset updated-files)
       (commit fileset tmp))))
 
-(defmulti content-parser (fn [language _] language))
+(defmulti content-parser
+  "Extension point for the `content` task
+  Takes the language to be parsed and a map of options.
+  Returns a map with the following keys:
+   - `:file-exts` A vector of file extensions, on which the parser will operate
+   - `:parse-form` A fn that takes a list of files to parse, and returns a form that will be evaled to perform the parsing
+   - `:pod` (optional) A pod that contains dependencies that the parser needs"
+  (fn [language _] language))
 
 (defmethod content-parser :default
   [language _]

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -103,35 +103,45 @@
       (perun/set-meta fileset updated-files)
       (commit fileset tmp))))
 
-(def ^:private markdown-deps
-  '[[org.pegdown/pegdown "1.6.0"]
-    [circleci/clj-yaml "0.5.5"]])
+(defmulti content-parser (fn [language _] language))
 
-(deftask markdown
-  "Parse markdown files
+(defmethod content-parser :default
+  [language _]
+  (perun/report-info "content" "Unknown content language %s" language))
 
-   This task will look for files ending with `md` or `markdown`
+(def ^:private +content-defaults+
+  {:languages [:markdown]})
+
+(deftask content
+  "Parse content files
+
+   This task will look for file types that perun can parse
    and add a `:content` key to their metadata containing the
-   HTML resulting from processing markdown file's content"
-  [o options OPTS edn "options to be passed to the markdown parser"]
-  (let [pod       (create-pod markdown-deps)
+   HTML resulting from processing the file's content"
+  [l languages     LANGUAGES [kw] "languages to parse (default: `[:markdown]`)"
+   p parse-options PARSEOPTS edn  "options to pass to underlying parsers (ex: {:markdown {:smarts true}})"]
+  (let [options   (merge +content-defaults+ *opts*)
+        parsers   (doall (map #(content-parser % (% parse-options)) (:languages options)))
         prev-meta (atom {})
         prev-fs   (atom nil)]
     (boot/with-pre-wrap fileset
-      (let [md-files (->> fileset
-                          (boot/fileset-diff @prev-fs)
-                          boot/user-files
-                          (boot/by-ext ["md" "markdown"])
-                          add-filedata)
-            ; process all removed markdown files
+      (let [updated-files (mapcat
+                           (fn [{:keys [file-exts parse-form pod]}]
+                             (let [files (->> fileset
+                                              (boot/fileset-diff @prev-fs)
+                                              boot/user-files
+                                              (boot/by-ext file-exts)
+                                              add-filedata)]
+                               (if pod
+                                 (pod/with-call-in @pod ~(parse-form files))
+                                 (eval (parse-form files)))))
+                           parsers)
             removed? (->> fileset
                           (boot/fileset-removed @prev-fs)
                           boot/user-files
-                          (boot/by-ext ["md" "markdown"])
+                          (boot/by-ext (mapcat :file-exts parsers))
                           (map #(boot/tmp-path %))
                           set)
-            updated-files (pod/with-call-in @pod
-                             (io.perun.markdown/parse-markdown ~md-files ~options))
             initial-metadata (perun/merge-meta* (perun/get-meta fileset) @prev-meta)
             ; Pure merge instead of `merge-with merge` (meta-meta).
             ; This is because updated metadata should replace previous metadata to
@@ -141,6 +151,26 @@
         (reset! prev-fs fileset)
         (reset! prev-meta final-metadata)
         (perun/set-meta fileset final-metadata)))))
+
+(def ^:private markdown-deps
+  '[[org.pegdown/pegdown "1.6.0"]
+    [circleci/clj-yaml "0.5.5"]])
+
+(defmethod content-parser :markdown
+  [_ options]
+  {:file-exts ["md" "markdown"]
+   :parse-form (fn [files] `(io.perun.content.markdown/parse-markdown ~files ~options))
+   :pod (create-pod markdown-deps)})
+
+(def ^:private asciidoc-deps
+  '[[org.asciidoctor/asciidoctorj "1.5.4.1"]
+    [circleci/clj-yaml "0.5.5"]])
+
+(defmethod content-parser :asciidoc
+  [_ options]
+  {:file-exts ["adoc" "asciidoc"]
+   :parse-form (fn [files] `(io.perun.content.asciidoc/parse-asciidoc ~files ~options))
+   :pod (create-pod asciidoc-deps)})
 
 (deftask global-metadata
   "Read global metadata from `perun.base.edn` or configured file.

--- a/src/io/perun/content.clj
+++ b/src/io/perun/content.clj
@@ -1,0 +1,50 @@
+(ns io.perun.content
+  (:require [clojure.string  :as str]
+            [clj-yaml.core   :as yaml]
+            [clojure.walk    :as walk])
+  (:import [flatland.ordered.map OrderedMap]
+           [flatland.ordered.set OrderedSet]))
+
+(def ^:dynamic *yaml-head* #"---\r?\n")
+
+(defn substr-between
+  "Find string that is nested in between two strings. Return first match.
+  Copied from https://github.com/funcool/cuerdas"
+  [s prefix suffix]
+  (cond
+    (nil? s) nil
+    (nil? prefix) nil
+    (nil? suffix) nil
+    :else
+    (some-> s
+            (str/split prefix)
+            second
+            (str/split suffix)
+            first)))
+
+(defn normal-colls
+  "Clj-yaml keeps order of map properties by using ordered maps. These are inconvenient
+  for us as the ordered library is not necessarily available in other pods."
+  [x]
+  (walk/postwalk
+    (fn [y]
+      (cond
+        (instance? OrderedMap y) (into {} y)
+        (instance? OrderedSet y) (into #{} y)
+        :else y))
+    x))
+
+(defn parse-file-metadata [file-content]
+  (if-let [metadata-str (substr-between file-content *yaml-head* *yaml-head*)]
+    (if-let [parsed-yaml (normal-colls (yaml/parse-string metadata-str))]
+      ; we use `original` file flag to distinguish between generated files
+      ; (e.x. created those by plugins)
+      (assoc parsed-yaml :original true)
+      {:original true})
+    {:original true}))
+
+(defn remove-metadata [content]
+  (let [splitted (str/split content *yaml-head* 3)]
+    (if (> (count splitted) 2)
+      (first (drop 2 splitted))
+      content)))

--- a/src/io/perun/content/asciidoc.clj
+++ b/src/io/perun/content/asciidoc.clj
@@ -1,0 +1,51 @@
+(ns io.perun.content.asciidoc
+  (:require [io.perun.core    :as perun]
+            [io.perun.content :as content]
+            [clojure.java.io  :as io])
+  (:import [org.asciidoctor Asciidoctor$Factory]))
+
+;; Copied from https://github.com/ruedigergad/clj-assorted-utils/blob/master/src/clj_assorted_utils/util.clj
+(defn convert-from-clojure-to-java
+  "Converts the given Clojure specific data structure (list, map, set, vector) into the equivalent \"pure\" Java data structure.
+   The mapping is as follows: list and vector -> ArrayList, map -> HashMap, set -> HashSet.
+   Nested data structures will be converted recursively."
+  [input]
+  (cond
+    (or
+      (list? input)
+      (vector? input)) (let [out (java.util.ArrayList.)]
+                         (doseq [in-element input]
+                           (if (coll? in-element)
+                             (.add out (convert-from-clojure-to-java in-element))
+                             (.add out in-element)))
+                         out)
+    (map? input) (let [out (java.util.HashMap.)]
+                   (doseq [in-element input]
+                     (if (coll? (val in-element))
+                       (.put out (key in-element) (convert-from-clojure-to-java (val in-element)))
+                       (.put out (key in-element) (val in-element))))
+                   out)
+    (set? input) (let [out (java.util.HashSet.)]
+                   (doseq [in-element input]
+                     (if (coll? in-element)
+                       (.add out (convert-from-clojure-to-java in-element))
+                       (.add out in-element)))
+                   out)))
+
+(defn asciidoc-to-html [file-content options]
+  (let [processor (Asciidoctor$Factory/create)
+        asciidoc-content (content/remove-metadata file-content)]
+    (.convert processor asciidoc-content (or (convert-from-clojure-to-java options)
+                                             (java.util.HashMap.)))))
+
+(defn process-file [file options]
+  (perun/report-debug "content" "processing asciidoc" (:filename file))
+  (let [file-content (-> file :full-path io/file slurp)
+        adoc-metadata (content/parse-file-metadata file-content)
+        html (asciidoc-to-html file-content options)]
+    (merge adoc-metadata {:content html} file)))
+
+(defn parse-asciidoc [asciidoc-files options]
+  (let [updated-files (doall (map #(process-file % options) asciidoc-files))]
+    (perun/report-info "content" "parsed %s asciidoc files" (count asciidoc-files))
+    updated-files))


### PR DESCRIPTION
This is a proposal for a pluggable content parsing system that can be extended beyond only markdown, both in user code and in perun itself.

Changes:
 - Abstracted the logic of `markdown` into the more general `content` task. It takes a vector of keywords that name markup languages to parse, which defaults to `[:markdown]`. Options to each language parser can be passed through using a map that looks like, for example  `{:markdown {:smarts true} :asciidoc {"attributes" {"backend" "docbook"}}`
 - Defined the `content-parser` multimethod as an extension point for plugging into the `content` task
 - Reimplemented `markdown`'s functionality by implementing a `content-parser` method for `:markdown`, so that by default `(content)` is equivalent to `(markdown)`
 - Added an `:asciidoc` method for `content-parser`, to demonstrate the addition of new parsers

I'm aware of one issue with the asciidoc parser: if the yaml metadata block at the beginning of a file, and the asciidoc contains any `----` delimited blocks, an error will be thrown.  I'd appreciate some input on this.

Let me know what you think!