### PR TITLE
use explicit :include-atom and :include-rss flags for inclusion in feeds

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -316,7 +316,7 @@
 
 (def ^:private +rss-defaults+
   {:filename "feed.rss"
-   :filterer :content
+   :filterer :include-rss
    :out-dir "public"})
 
 (deftask rss
@@ -344,7 +344,7 @@
 
 (def ^:private +atom-defaults+
   {:filename "atom.xml"
-   :filterer :content
+   :filterer :include-atom
    :out-dir "public"})
 
 (deftask atom-feed

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -76,14 +76,19 @@
         :else y))
     x))
 
+(def ^:private default-meta
+  {:original true
+   :include-rss true
+   :include-atom true})
+
 (defn parse-file-metadata [file-content]
   (if-let [metadata-str (substr-between file-content *yaml-head* *yaml-head*)]
     (if-let [parsed-yaml (normal-colls (yaml/parse-string metadata-str))]
       ; we use `original` file flag to distinguish between generated files
       ; (e.x. created those by plugins)
-      (assoc parsed-yaml :original true)
-      {:original true})
-    {:original true}))
+      (merge default-meta parsed-yaml)
+      default-meta)
+    default-meta))
 
 (defn remove-metadata [content]
   (let [splitted (str/split content *yaml-head* 3)]


### PR DESCRIPTION
Following @MartyGentillon, here: https://github.com/hashobject/perun/pull/109#issuecomment-263157303.  Intent is more clear, and this change or something like it is a prerequisite for fulfilling the goals of #109.