### PR TITLE
Add a `:meta` task option to `markdown`, `render`, and `collection`

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -417,7 +417,7 @@
         options (merge +render-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
       (pod/with-call-in @render-pod
-          (io.perun.render/update!))
+        (io.perun.render/update!))
       (let [files (filter (:filterer options) (perun/get-meta fileset))
             updated-files (doall
                            (for [{:keys [path] :as file} files]

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -78,8 +78,7 @@
 
 (defn parse-file-metadata [file-content]
   (when-let [metadata-str (substr-between file-content *yaml-head* *yaml-head*)]
-    (when-let [parsed-yaml (normal-colls (yaml/parse-string metadata-str))]
-      parsed-yaml)))
+    (normal-colls (yaml/parse-string metadata-str))))
 
 (defn remove-metadata [content]
   (let [splitted (str/split content *yaml-head* 3)]


### PR DESCRIPTION
Allows more control of entry metadata in the case of `markdown`, and any
control at all in the cases of `render` and `collection`, following @MartyGentillon and @martinklepsch, in https://github.com/hashobject/perun/pull/109#issuecomment-263201298 and https://github.com/hashobject/perun/pull/114#issuecomment-264083450, respectively.

Having `:meta` in `render` isn't terribly useful now, but in the spirit of #109, it would be consistent to have this option on any task that deals with `:content`.