### PR TITLE
Add `:io.perun/trace` to file metadata

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -77,3 +77,6 @@ All posts have a filename which is used as a key to identify the post.
 - **:include-rss**
     - Set by: *markdown*, true by default
     - Used by: *rss*
+- **:io.perun/trace**
+    - Conjed onto by every task that modifies metadata
+    - Serves as a record of tasks to touch a file

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -41,6 +41,8 @@
     fileset))
 
 (defn trace
+  "Helper function, conj `kw` onto the `:io.perun/trace` metadata
+  key of each entry in `entries`"
   [kw entries]
   (map #(update-in % [:io.perun/trace] (fnil conj []) kw) entries))
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -40,6 +40,10 @@
         (io.perun.print-meta/print-meta ~(vec (map map-fn (perun/get-meta fileset))))))
     fileset))
 
+(defn trace
+  [kw entries]
+  (map #(update-in % [:perun/trace] (fnil conj []) kw) entries))
+
 (def ^:private filedata-deps
   '[[com.novemberain/pantomime "2.8.0"]])
 
@@ -55,7 +59,10 @@
    establish metadata structure."
   []
   (boot/with-pre-wrap fileset
-    (let [updated-files (add-filedata (boot/user-files fileset))]
+    (let [updated-files (->> fileset
+                             boot/user-files
+                             add-filedata
+                             (trace :perun/base))]
       (perun/set-meta fileset updated-files))))
 
 (def ^:private images-dimensions-deps
@@ -71,7 +78,8 @@
           files (->> fileset
                      boot/user-files
                      (boot/by-ext ["png" "jpeg" "jpg"])
-                     add-filedata)
+                     add-filedata
+                     (trace :perun/images-dimensions))
           updated-files (pod/with-call-in @pod
                          (io.perun.contrib.images-dimensions/images-dimensions ~files {}))]
       (perun/set-meta fileset updated-files))))
@@ -96,7 +104,8 @@
           files (->> fileset
                      boot/user-files
                      (boot/by-ext ["png" "jpeg" "jpg"])
-                     add-filedata)
+                     add-filedata
+                     (trace :perun/images-resize))
           updated-files (pod/with-call-in @pod
                          (io.perun.contrib.images-resize/images-resize ~(.getPath tmp) ~files ~options))]
       (perun/report-debug "images-resize" "new resized images" updated-files)
@@ -133,11 +142,15 @@
             updated-files (pod/with-call-in @pod
                              (io.perun.markdown/parse-markdown ~md-files ~options))
             initial-metadata (perun/merge-meta* (perun/get-meta fileset) @prev-meta)
-            ; Pure merge instead of `merge-with merge` (meta-meta).
-            ; This is because updated metadata should replace previous metadata to
-            ; correctly handle cases where a metadata key is removed from post metadata.
-            final-metadata   (vals (merge (perun/key-meta initial-metadata) (perun/key-meta updated-files)))
-            final-metadata   (remove #(-> % :path removed?) final-metadata)]
+            final-metadata   (->> updated-files
+                                  perun/key-meta
+                                  ; Pure merge instead of `merge-with merge` (meta-meta).
+                                  ; This is because updated metadata should replace previous metadata to
+                                  ; correctly handle cases where a metadata key is removed from post metadata.
+                                  (merge (perun/key-meta initial-metadata))
+                                  vals
+                                  (remove #(-> % :path removed?))
+                                  (trace :perun/markdown))]
         (reset! prev-fs fileset)
         (reset! prev-meta final-metadata)
         (perun/set-meta fileset final-metadata)))))
@@ -171,8 +184,9 @@
   (let [pod (create-pod ttr-deps)]
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
-            updated-files (pod/with-call-in @pod
-                            (io.perun.ttr/calculate-ttr ~files))]
+            updated-files (trace :perun/ttr
+                                 (pod/with-call-in @pod
+                                   (io.perun.ttr/calculate-ttr ~files)))]
         (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-files))
         (perun/set-meta fileset updated-files)))))
 
@@ -182,8 +196,9 @@
   (let [pod (create-pod ttr-deps)]
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
-            updated-files (pod/with-call-in @pod
-                            (io.perun.word-count/count-words ~files))]
+            updated-files (trace :perun/word-count
+                                 (pod/with-call-in @pod
+                                   (io.perun.word-count/count-words ~files)))]
         (perun/report-debug "word-count" "counted words" (map :word-count updated-files))
         (perun/set-meta fileset updated-files)))))
 
@@ -198,8 +213,9 @@
   (let [pod (create-pod gravatar-deps)]
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
-            updated-files (pod/with-call-in @pod
-                            (io.perun.gravatar/find-gravatar ~files ~source-key ~target-key))]
+            updated-files (trace :perun/gravatar
+                                 (pod/with-call-in @pod
+                                   (io.perun.gravatar/find-gravatar ~files ~source-key ~target-key)))]
         (perun/report-debug "gravatar" "found gravatars" (map target-key updated-files))
        (perun/set-meta fileset updated-files)))))
 
@@ -209,7 +225,9 @@
   []
   (boot/with-pre-wrap fileset
     (let [files         (perun/get-meta fileset)
-          updated-files (remove #(true? (:draft %)) files)]
+          updated-files (->> files
+                             (remove #(true? (:draft %)))
+                             (trace :perun/draft))]
       (perun/report-info "draft" "removed draft files. Remaining %s files" (count updated-files))
       (perun/set-meta fileset updated-files))))
 
@@ -220,7 +238,9 @@
     (let [files           (perun/get-meta fileset)
           global-meta     (perun/get-global-meta fileset)
           now             (java.util.Date.)
-          updated-files   (map #(assoc % :date-build now) files)
+          updated-files   (->> files
+                               (map #(assoc % :date-build now))
+                               (trace :perun/build-date))
           new-global-meta (assoc global-meta :date-build now)
           updated-fs      (perun/set-meta fileset updated-files)]
         (perun/report-debug "build-date" "added :date-build" (map :date-build updated-files))
@@ -243,7 +263,9 @@
   (boot/with-pre-wrap fileset
     (let [slug-fn       (or slug-fn default-slug-fn)
           files         (perun/get-meta fileset)
-          updated-files (map #(assoc % :slug (-> % :filename slug-fn)) files)]
+          updated-files (->> files
+                             (map #(assoc % :slug (-> % :filename slug-fn)))
+                             (trace :perun/slug))]
       (perun/report-debug "slug" "generated slugs" (map :slug updated-files))
       (perun/report-info "slug" "added slugs to %s files" (count updated-files))
       (perun/set-meta fileset updated-files))))
@@ -263,7 +285,9 @@
     (let [options       (merge +permalink-defaults+ *opts*)
           files         (filter (:filterer options) (perun/get-meta fileset))
           assoc-perma   #(assoc % :permalink ((:permalink-fn options) %))
-          updated-files (map assoc-perma files)]
+          updated-files (->> files
+                             (map assoc-perma)
+                             (trace :perun/permalink))]
       (perun/report-debug "permalink"  "generated permalinks" (map :permalink updated-files))
       (perun/report-info "permalink" "added permalinks to %s files" (count updated-files))
       (perun/merge-meta fileset updated-files))))
@@ -282,7 +306,9 @@
                   :canonical-url
                   ; we need to call perun/relativize-url to remove leading / because base-url has trailing /
                   (str base-url (perun/relativize-url (:permalink  %))))
-          updated-files (map assoc-can-url files)]
+          updated-files (->> files
+                             (map assoc-can-url)
+                             (trace :perun/canonical-url))]
         (perun/report-info "canonical-url" "added canonical urls to %s files" (count updated-files))
         (perun/merge-meta fileset updated-files))))
 
@@ -494,7 +520,7 @@
                                             (perun/report-info "collection" "rendered collection %s" page)
                                             new-entry)))
                                       grouped-files))
-                    updated-files    (apply conj files new-files)
+                    updated-files    (apply conj files (trace :perun/collection new-files))
                     updated-fileset  (perun/set-meta fileset updated-files)]
                   (commit updated-fileset tmp))))))
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -42,7 +42,7 @@
 
 (defn trace
   [kw entries]
-  (map #(update-in % [:perun/trace] (fnil conj []) kw) entries))
+  (map #(update-in % [:io.perun/trace] (fnil conj []) kw) entries))
 
 (def ^:private filedata-deps
   '[[com.novemberain/pantomime "2.8.0"]])
@@ -62,7 +62,7 @@
     (let [updated-files (->> fileset
                              boot/user-files
                              add-filedata
-                             (trace :perun/base))]
+                             (trace :io.perun/base))]
       (perun/set-meta fileset updated-files))))
 
 (def ^:private images-dimensions-deps
@@ -79,7 +79,7 @@
                      boot/user-files
                      (boot/by-ext ["png" "jpeg" "jpg"])
                      add-filedata
-                     (trace :perun/images-dimensions))
+                     (trace :io.perun/images-dimensions))
           updated-files (pod/with-call-in @pod
                          (io.perun.contrib.images-dimensions/images-dimensions ~files {}))]
       (perun/set-meta fileset updated-files))))
@@ -105,7 +105,7 @@
                      boot/user-files
                      (boot/by-ext ["png" "jpeg" "jpg"])
                      add-filedata
-                     (trace :perun/images-resize))
+                     (trace :io.perun/images-resize))
           updated-files (pod/with-call-in @pod
                          (io.perun.contrib.images-resize/images-resize ~(.getPath tmp) ~files ~options))]
       (perun/report-debug "images-resize" "new resized images" updated-files)
@@ -150,7 +150,7 @@
                                   (merge (perun/key-meta initial-metadata))
                                   vals
                                   (remove #(-> % :path removed?))
-                                  (trace :perun/markdown))]
+                                  (trace :io.perun/markdown))]
         (reset! prev-fs fileset)
         (reset! prev-meta final-metadata)
         (perun/set-meta fileset final-metadata)))))
@@ -184,7 +184,7 @@
   (let [pod (create-pod ttr-deps)]
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
-            updated-files (trace :perun/ttr
+            updated-files (trace :io.perun/ttr
                                  (pod/with-call-in @pod
                                    (io.perun.ttr/calculate-ttr ~files)))]
         (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-files))
@@ -196,7 +196,7 @@
   (let [pod (create-pod ttr-deps)]
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
-            updated-files (trace :perun/word-count
+            updated-files (trace :io.perun/word-count
                                  (pod/with-call-in @pod
                                    (io.perun.word-count/count-words ~files)))]
         (perun/report-debug "word-count" "counted words" (map :word-count updated-files))
@@ -213,7 +213,7 @@
   (let [pod (create-pod gravatar-deps)]
     (boot/with-pre-wrap fileset
       (let [files         (perun/get-meta fileset)
-            updated-files (trace :perun/gravatar
+            updated-files (trace :io.perun/gravatar
                                  (pod/with-call-in @pod
                                    (io.perun.gravatar/find-gravatar ~files ~source-key ~target-key)))]
         (perun/report-debug "gravatar" "found gravatars" (map target-key updated-files))
@@ -227,7 +227,7 @@
     (let [files         (perun/get-meta fileset)
           updated-files (->> files
                              (remove #(true? (:draft %)))
-                             (trace :perun/draft))]
+                             (trace :io.perun/draft))]
       (perun/report-info "draft" "removed draft files. Remaining %s files" (count updated-files))
       (perun/set-meta fileset updated-files))))
 
@@ -240,7 +240,7 @@
           now             (java.util.Date.)
           updated-files   (->> files
                                (map #(assoc % :date-build now))
-                               (trace :perun/build-date))
+                               (trace :io.perun/build-date))
           new-global-meta (assoc global-meta :date-build now)
           updated-fs      (perun/set-meta fileset updated-files)]
         (perun/report-debug "build-date" "added :date-build" (map :date-build updated-files))
@@ -265,7 +265,7 @@
           files         (perun/get-meta fileset)
           updated-files (->> files
                              (map #(assoc % :slug (-> % :filename slug-fn)))
-                             (trace :perun/slug))]
+                             (trace :io.perun/slug))]
       (perun/report-debug "slug" "generated slugs" (map :slug updated-files))
       (perun/report-info "slug" "added slugs to %s files" (count updated-files))
       (perun/set-meta fileset updated-files))))
@@ -287,7 +287,7 @@
           assoc-perma   #(assoc % :permalink ((:permalink-fn options) %))
           updated-files (->> files
                              (map assoc-perma)
-                             (trace :perun/permalink))]
+                             (trace :io.perun/permalink))]
       (perun/report-debug "permalink"  "generated permalinks" (map :permalink updated-files))
       (perun/report-info "permalink" "added permalinks to %s files" (count updated-files))
       (perun/merge-meta fileset updated-files))))
@@ -308,7 +308,7 @@
                   (str base-url (perun/relativize-url (:permalink  %))))
           updated-files (->> files
                              (map assoc-can-url)
-                             (trace :perun/canonical-url))]
+                             (trace :io.perun/canonical-url))]
         (perun/report-info "canonical-url" "added canonical urls to %s files" (count updated-files))
         (perun/merge-meta fileset updated-files))))
 
@@ -520,7 +520,7 @@
                                             (perun/report-info "collection" "rendered collection %s" page)
                                             new-entry)))
                                       grouped-files))
-                    updated-files    (apply conj files (trace :perun/collection new-files))
+                    updated-files    (apply conj files (trace :io.perun/collection new-files))
                     updated-fileset  (perun/set-meta fileset updated-files)]
                   (commit updated-fileset tmp))))))
 


### PR DESCRIPTION
Each built-in task that modifies file metadata conjes a keyword onto the `:perun/trace` vector. This will aid in debugging, and possibly have applications in tasks.

Following @MartyGentillon here: https://github.com/hashobject/perun/pull/113#issuecomment-263158233.  Two notes:

 - I went with namespaced keywords.  It felt right, and I was more comfortable breaking with the existing style with `:perun/trace` than with `:include-rss` and `:include-atom`, because `:perun/trace` feels like a different kind of metadata.  For the values in the vector, I went with `:perun/` namespaced keywords as well, because 3rd party code may want to hook into the `trace` functionality.  I still think that namespaced keywords are a good idea pretty much everywhere in perun, fwiw.
 - Some tasks, most notably `render`, don't use `trace`, because they don't currently modify metadata.  If #116 gets merged before this one, I'll modify this PR to `trace` `render` as well.