### PR TITLE
Make default filterers consistent among tasks

### DIFF
--- a/examples/blog/build.boot
+++ b/examples/blog/build.boot
@@ -3,14 +3,12 @@
   :resource-paths #{"resources"}
   :dependencies '[[perun "0.4.0-SNAPSHOT"]
                   [hiccup "1.0.5"]
-                  [pandeiro/boot-http "0.6.3-SNAPSHOT"]
-                  [jeluard/boot-notify "0.1.2" :scope "test"]])
+                  [pandeiro/boot-http "0.6.3-SNAPSHOT"]])
 
 (require '[io.perun :refer :all]
          '[io.perun.example.index :as index-view]
          '[io.perun.example.post :as post-view]
-         '[pandeiro.boot-http :refer [serve]]
-         '[jeluard.boot-notify :refer [notify]])
+         '[pandeiro.boot-http :refer [serve]])
 
 (deftask build
   "Build test blog. This task is just for testing different plugins together."
@@ -28,7 +26,7 @@
         (build-date)
         (gravatar :source-key :author-email :target-key :author-gravatar)
         (render :renderer 'io.perun.example.post/render)
-        (collection :renderer 'io.perun.example.index/render :page "index.html" :filterer identity)
+        (collection :renderer 'io.perun.example.index/render :page "index.html")
         (inject-scripts :scripts #{"start.js"})
         (sitemap)
         (rss :description "Hashobject blog")

--- a/examples/expose/build.boot
+++ b/examples/expose/build.boot
@@ -3,14 +3,12 @@
   :resource-paths #{"resources"}
   :dependencies '[[perun "0.4.0-SNAPSHOT"]
                   [hiccup "1.0.5"]
-                  [pandeiro/boot-http "0.6.3-SNAPSHOT"]
-                  [jeluard/boot-notify "0.1.2" :scope "test"]])
+                  [pandeiro/boot-http "0.6.3-SNAPSHOT"]])
 
 (require '[io.perun :refer :all]
          '[io.perun.example.index :as index-view]
          '[io.perun.example.post :as post-view]
-         '[pandeiro.boot-http :refer [serve]]
-         '[jeluard.boot-notify :refer [notify]])
+         '[pandeiro.boot-http :refer [serve]])
 
 (deftask build
   "Build test blog. This task is just for testing different plugins together."
@@ -28,7 +26,7 @@
         (canonical-url)
         (build-date)
         (render :renderer 'io.perun.example.post/render)
-        (collection :renderer 'io.perun.example.index/render :page "index.html" :filterer identity)
+        (collection :renderer 'io.perun.example.index/render :page "index.html")
         (sitemap)
         (notify)))
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -227,38 +227,39 @@
         (perun/report-info "build-date" "added date-build to %s files" (count updated-files))
       (perun/set-global-meta updated-fs new-global-meta))))
 
-(defn ^:private default-slug-fn [filename]
-  "Parses `slug` portion out of the filename in the format: YYYY-MM-DD-slug-title.ext
-
-   Jekyll uses the same format by default."
-  (->> (string/split filename #"[-\.]")
-       (drop 3)
-       drop-last
-       (string/join "-")
-       string/lower-case))
+(def ^:private +slug-defaults+
+  {; Parses `slug` portion out of the filename in the format: YYYY-MM-DD-slug-title.ext
+   ; Jekyll uses the same format by default.
+   :slug-fn (fn [filename] (->> (string/split filename #"[-\.]")
+                                (drop 3)
+                                drop-last
+                                (string/join "-")
+                                string/lower-case))
+   :filterer :content})
 
 (deftask slug
   "Adds :slug key to files metadata. Slug is derived from filename."
-  [s slug-fn SLUGFN code "function to build slug from filename"]
+  [s slug-fn  SLUGFN code "function to build slug from filename"
+   _ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
   (boot/with-pre-wrap fileset
-    (let [slug-fn       (or slug-fn default-slug-fn)
-          files         (perun/get-meta fileset)
+    (let [options       (merge +slug-defaults+ *opts*)
+          slug-fn       (:slug-fn options)
+          files         (filter (:filterer options) (perun/get-meta fileset))
           updated-files (map #(assoc % :slug (-> % :filename slug-fn)) files)]
       (perun/report-debug "slug" "generated slugs" (map :slug updated-files))
       (perun/report-info "slug" "added slugs to %s files" (count updated-files))
       (perun/set-meta fileset updated-files))))
 
-
 (def ^:private +permalink-defaults+
   {:permalink-fn (fn [m] (perun/absolutize-url (str (:slug m) "/index.html")))
-   :filterer     identity})
+   :filterer     :content})
 
 (deftask permalink
   "Adds :permalink key to files metadata. Value of key will determine target path.
 
    Make files permalinked. E.x. about.html will become about/index.html"
   [p permalink-fn PERMALINKFN code "function to build permalink from TmpFile metadata"
-   _ filterer     FILTER      code "predicate to use for selecting entries (default: `identity`)"]
+   _ filterer     FILTER      code "predicate to use for selecting entries (default: `:content`)"]
   (boot/with-pre-wrap fileset
     (let [options       (merge +permalink-defaults+ *opts*)
           files         (filter (:filterer options) (perun/get-meta fileset))
@@ -268,14 +269,18 @@
       (perun/report-info "permalink" "added permalinks to %s files" (count updated-files))
       (perun/merge-meta fileset updated-files))))
 
+(def ^:private +canonical-url-defaults+
+  {:filterer :content})
+
 (deftask canonical-url
   "Adds :canonical-url key to files metadata.
 
    The url is concatenation of :base-url in global metadata and files' permaurl.
    The base-url must end with '/'."
-  []
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
   (boot/with-pre-wrap fileset
-    (let [files         (perun/get-meta fileset)
+    (let [options       (merge +canonical-url-defaults+ *opts*)
+          files         (filter (:filterer options) (perun/get-meta fileset))
           base-url      (perun/assert-base-url (:base-url (perun/get-global-meta fileset)))
           assoc-can-url
             #(assoc %

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -165,39 +165,51 @@
 (def ^:private ttr-deps
   '[[time-to-read "0.1.0"]])
 
+(def ^:private +ttr-defaults+
+  {:filterer :content})
+
 (deftask ttr
   "Calculate time to read for each file. Add `:ttr` key to the files' meta"
-  []
-  (let [pod (create-pod ttr-deps)]
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
+  (let [pod     (create-pod ttr-deps)
+        options (merge +ttr-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files         (perun/get-meta fileset)
+      (let [files         (filter (:filterer options) (perun/get-meta fileset))
             updated-files (pod/with-call-in @pod
                             (io.perun.ttr/calculate-ttr ~files))]
         (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-files))
         (perun/set-meta fileset updated-files)))))
 
+(def ^:private +word-count-defaults+
+  {:filterer :content})
+
 (deftask word-count
   "Count words in each file. Add `:word-count` key to the files' meta"
-  []
-  (let [pod (create-pod ttr-deps)]
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
+  (let [pod (create-pod ttr-deps)
+        options (merge +word-count-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files         (perun/get-meta fileset)
+      (let [files         (filter (:filterer options) (perun/get-meta fileset))
             updated-files (pod/with-call-in @pod
                             (io.perun.word-count/count-words ~files))]
         (perun/report-debug "word-count" "counted words" (map :word-count updated-files))
         (perun/set-meta fileset updated-files)))))
 
-
 (def ^:private gravatar-deps
   '[[gravatar "0.1.0"]])
+
+(def ^:private +gravatar-defaults+
+  {:filterer :content})
 
 (deftask gravatar
   "Find gravatar urls using emails"
   [s source-key SOURCE-PROP kw "email property used to lookup gravatar url"
-   t target-key TARGET-PROP kw "property name to store gravatar url"]
-  (let [pod (create-pod gravatar-deps)]
+   t target-key TARGET-PROP kw "property name to store gravatar url"
+   _ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
+  (let [pod (create-pod gravatar-deps)
+        options (merge +gravatar-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files         (perun/get-meta fileset)
+      (let [files         (filter (:filterer options) (perun/get-meta fileset))
             updated-files (pod/with-call-in @pod
                             (io.perun.gravatar/find-gravatar ~files ~source-key ~target-key))]
         (perun/report-debug "gravatar" "found gravatars" (map target-key updated-files))
@@ -213,11 +225,15 @@
       (perun/report-info "draft" "removed draft files. Remaining %s files" (count updated-files))
       (perun/set-meta fileset updated-files))))
 
+(def ^:private +build-date-defaults+
+  {:filterer :content})
+
 (deftask build-date
   "Add :date-build attribute to each file metadata and also to the global meta"
-  []
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
   (boot/with-pre-wrap fileset
-    (let [files           (perun/get-meta fileset)
+    (let [options         (merge +build-date-defaults+ *opts*)
+          files           (filter (:filterer options) (perun/get-meta fileset))
           global-meta     (perun/get-global-meta fileset)
           now             (java.util.Date.)
           updated-files   (map #(assoc % :date-build now) files)


### PR DESCRIPTION
Give filterers (default `:content`) to `slug` and `canonical-url`,
and change `permalink`'s default filterer to `:content`. This is one
step on the road to a consistent content pipeline, as discussed in
#109