### PR TITLE
Correctly parse only changed markdown files on the second `watch` loop

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -118,8 +118,7 @@
         prev-meta (atom {})
         prev-fs   (atom nil)]
     (boot/with-pre-wrap fileset
-      (let [md-files (->> fileset
-                          (boot/fileset-diff @prev-fs)
+      (let [md-files (->> (boot/fileset-diff @prev-fs fileset :hash)
                           boot/user-files
                           (boot/by-ext ["md" "markdown"])
                           add-filedata)


### PR DESCRIPTION
Doing a full compare caused all the markdown to be re-parsed on the
second loop, because for some reason, the timestamp on the file
changed. Since we're only interested in the content of the file, just
comparing the file's hash to the previous version is sufficient, and
produces the correct behavior.