### PR TITLE
Use boot file metadata instead of maintaining a separate map

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -6,7 +6,8 @@
             [clojure.java.io :as io]
             [clojure.string :as string]
             [clojure.edn :as edn]
-            [io.perun.core :as perun]))
+            [io.perun.core :as perun]
+            [io.perun.meta :as pm]))
 
 (def ^:private global-deps
   '[])
@@ -37,7 +38,7 @@
   (boot/with-pre-wrap fileset
     (let [map-fn (or map-fn identity)]
       (pod/with-call-in @print-meta-pod
-        (io.perun.print-meta/print-meta ~(vec (map map-fn (perun/get-meta fileset))))))
+        (io.perun.print-meta/print-meta ~(vec (map map-fn (pm/get-meta fileset))))))
     fileset))
 
 (defn trace
@@ -65,7 +66,7 @@
                              boot/user-files
                              add-filedata
                              (trace :io.perun/base))]
-      (perun/set-meta fileset updated-files))))
+      (pm/set-meta fileset updated-files))))
 
 (def ^:private images-dimensions-deps
   '[[image-resizer "0.1.8"]])
@@ -84,7 +85,7 @@
                      (trace :io.perun/images-dimensions))
           updated-files (pod/with-call-in @pod
                          (io.perun.contrib.images-dimensions/images-dimensions ~files {}))]
-      (perun/set-meta fileset updated-files))))
+      (pm/set-meta fileset updated-files))))
 
 (def ^:private images-resize-deps
   '[[image-resizer "0.1.8"]])
@@ -111,7 +112,7 @@
           updated-files (pod/with-call-in @pod
                          (io.perun.contrib.images-resize/images-resize ~(.getPath tmp) ~files ~options))]
       (perun/report-debug "images-resize" "new resized images" updated-files)
-      (perun/set-meta fileset updated-files)
+      (pm/set-meta fileset updated-files)
       (commit fileset tmp))))
 
 (def ^:private markdown-deps
@@ -142,8 +143,8 @@
             updated-files (trace :io.perun/markdown
                                  (pod/with-call-in @pod
                                    (io.perun.markdown/parse-markdown ~md-files ~options)))
-            final-metadata (perun/merge-meta* (perun/get-meta @prev-fs) updated-files)
-            new-fs (perun/set-meta fileset final-metadata)]
+            final-metadata (pm/merge-meta* (pm/get-meta @prev-fs) updated-files)
+            new-fs (pm/set-meta fileset final-metadata)]
         (reset! prev-fs new-fs)
         new-fs))))
 
@@ -165,7 +166,7 @@
                      slurp
                      read-string)]
          (perun/report-info "global-metadata" "read global metadata from %s" meta-file)
-         (perun/set-global-meta fileset global-meta))))
+         (pm/set-global-meta fileset global-meta))))
 
 (def ^:private ttr-deps
   '[[time-to-read "0.1.0"]])
@@ -179,12 +180,12 @@
   (let [pod     (create-pod ttr-deps)
         options (merge +ttr-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files         (filter (:filterer options) (perun/get-meta fileset))
+      (let [files         (filter (:filterer options) (pm/get-meta fileset))
             updated-files (trace :io.perun/ttr
                                  (pod/with-call-in @pod
                                    (io.perun.ttr/calculate-ttr ~files)))]
         (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-files))
-        (perun/set-meta fileset updated-files)))))
+        (pm/set-meta fileset updated-files)))))
 
 (def ^:private +word-count-defaults+
   {:filterer :content})
@@ -195,12 +196,12 @@
   (let [pod (create-pod ttr-deps)
         options (merge +word-count-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files         (filter (:filterer options) (perun/get-meta fileset))
+      (let [files         (filter (:filterer options) (pm/get-meta fileset))
             updated-files (trace :io.perun/word-count
                                  (pod/with-call-in @pod
                                    (io.perun.word-count/count-words ~files)))]
         (perun/report-debug "word-count" "counted words" (map :word-count updated-files))
-        (perun/set-meta fileset updated-files)))))
+        (pm/set-meta fileset updated-files)))))
 
 (def ^:private gravatar-deps
   '[[gravatar "0.1.0"]])
@@ -216,24 +217,24 @@
   (let [pod (create-pod gravatar-deps)
         options (merge +gravatar-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files         (filter (:filterer options) (perun/get-meta fileset))
+      (let [files         (filter (:filterer options) (pm/get-meta fileset))
             updated-files (trace :io.perun/gravatar
                                  (pod/with-call-in @pod
                                    (io.perun.gravatar/find-gravatar ~files ~source-key ~target-key)))]
         (perun/report-debug "gravatar" "found gravatars" (map target-key updated-files))
-       (perun/set-meta fileset updated-files)))))
+       (pm/set-meta fileset updated-files)))))
 
 ;; Should be handled by more generic filterer options to other tasks
 (deftask draft
   "Exclude draft files"
   []
   (boot/with-pre-wrap fileset
-    (let [files         (perun/get-meta fileset)
+    (let [files         (pm/get-meta fileset)
           updated-files (->> files
                              (remove #(true? (:draft %)))
                              (trace :io.perun/draft))]
       (perun/report-info "draft" "removed draft files. Remaining %s files" (count updated-files))
-      (perun/set-meta fileset updated-files))))
+      (pm/set-meta fileset updated-files))))
 
 (def ^:private +build-date-defaults+
   {:filterer :content})
@@ -243,17 +244,17 @@
   [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
   (boot/with-pre-wrap fileset
     (let [options         (merge +build-date-defaults+ *opts*)
-          files           (filter (:filterer options) (perun/get-meta fileset))
-          global-meta     (perun/get-global-meta fileset)
+          files           (filter (:filterer options) (pm/get-meta fileset))
+          global-meta     (pm/get-global-meta fileset)
           now             (java.util.Date.)
           updated-files   (->> files
                                (map #(assoc % :date-build now))
                                (trace :io.perun/build-date))
           new-global-meta (assoc global-meta :date-build now)
-          updated-fs      (perun/set-meta fileset updated-files)]
+          updated-fs      (pm/set-meta fileset updated-files)]
         (perun/report-debug "build-date" "added :date-build" (map :date-build updated-files))
         (perun/report-info "build-date" "added date-build to %s files" (count updated-files))
-      (perun/set-global-meta updated-fs new-global-meta))))
+      (pm/set-global-meta updated-fs new-global-meta))))
 
 (def ^:private +slug-defaults+
   {; Parses `slug` portion out of the filename in the format: YYYY-MM-DD-slug-title.ext
@@ -272,13 +273,13 @@
   (boot/with-pre-wrap fileset
     (let [options       (merge +slug-defaults+ *opts*)
           slug-fn       (:slug-fn options)
-          files         (filter (:filterer options) (perun/get-meta fileset))
+          files         (filter (:filterer options) (pm/get-meta fileset))
           updated-files (->> files
                              (map #(assoc % :slug (-> % :filename slug-fn)))
                              (trace :io.perun/slug))]
       (perun/report-debug "slug" "generated slugs" (map :slug updated-files))
       (perun/report-info "slug" "added slugs to %s files" (count updated-files))
-      (perun/set-meta fileset updated-files))))
+      (pm/set-meta fileset updated-files))))
 
 (def ^:private +permalink-defaults+
   {:permalink-fn (fn [m] (perun/absolutize-url (str (:slug m) "/index.html")))
@@ -292,14 +293,14 @@
    _ filterer     FILTER      code "predicate to use for selecting entries (default: `:content`)"]
   (boot/with-pre-wrap fileset
     (let [options       (merge +permalink-defaults+ *opts*)
-          files         (filter (:filterer options) (perun/get-meta fileset))
+          files         (filter (:filterer options) (pm/get-meta fileset))
           assoc-perma   #(assoc % :permalink ((:permalink-fn options) %))
           updated-files (->> files
                              (map assoc-perma)
                              (trace :io.perun/permalink))]
       (perun/report-debug "permalink"  "generated permalinks" (map :permalink updated-files))
       (perun/report-info "permalink" "added permalinks to %s files" (count updated-files))
-      (perun/merge-meta fileset updated-files))))
+      (pm/merge-meta fileset updated-files))))
 
 (def ^:private +canonical-url-defaults+
   {:filterer :content})
@@ -312,8 +313,8 @@
   [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
   (boot/with-pre-wrap fileset
     (let [options       (merge +canonical-url-defaults+ *opts*)
-          files         (filter (:filterer options) (perun/get-meta fileset))
-          base-url      (perun/assert-base-url (:base-url (perun/get-global-meta fileset)))
+          files         (filter (:filterer options) (pm/get-meta fileset))
+          base-url      (perun/assert-base-url (:base-url (pm/get-global-meta fileset)))
           assoc-can-url
             #(assoc %
                   :canonical-url
@@ -323,7 +324,7 @@
                              (map assoc-can-url)
                              (trace :io.perun/canonical-url))]
         (perun/report-info "canonical-url" "added canonical urls to %s files" (count updated-files))
-        (perun/merge-meta fileset updated-files))))
+        (pm/merge-meta fileset updated-files))))
 
 (def ^:private sitemap-deps
   '[[sitemap "0.2.4"]
@@ -344,7 +345,7 @@
         tmp     (boot/tmp-dir!)
         options (merge +sitemap-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files (filter (:filterer options) (perun/get-meta fileset))]
+      (let [files (filter (:filterer options) (pm/get-meta fileset))]
         (pod/with-call-in @pod
           (io.perun.sitemap/generate-sitemap ~(.getPath tmp) ~files ~(dissoc options :filterer)))
         (commit fileset tmp)))))
@@ -369,9 +370,9 @@
   (let [pod (create-pod rss-deps)
         tmp (boot/tmp-dir!)]
     (boot/with-pre-wrap fileset
-      (let [global-meta   (perun/get-global-meta fileset)
+      (let [global-meta   (pm/get-global-meta fileset)
             options       (merge +rss-defaults+ global-meta *opts*)
-            files         (filter (:filterer options) (perun/get-meta fileset))]
+            files         (filter (:filterer options) (pm/get-meta fileset))]
         (perun/assert-base-url (:base-url options))
         (pod/with-call-in @pod
           (io.perun.rss/generate-rss ~(.getPath tmp) ~files ~(dissoc options :filterer)))
@@ -398,9 +399,9 @@
   (let [pod (create-pod atom-deps)
         tmp (boot/tmp-dir!)]
     (boot/with-pre-wrap fileset
-      (let [global-meta   (perun/get-global-meta fileset)
+      (let [global-meta   (pm/get-global-meta fileset)
             options       (merge +atom-defaults+ global-meta *opts*)
-            files         (filter (:filterer options) (perun/get-meta fileset))]
+            files         (filter (:filterer options) (pm/get-meta fileset))]
         (perun/assert-base-url (:base-url options))
         (pod/with-call-in @pod
           (io.perun.atom/generate-atom ~(.getPath tmp) ~files ~(dissoc options :filterer)))
@@ -450,11 +451,11 @@
     (boot/with-pre-wrap fileset
       (pod/with-call-in @render-pod
         (io.perun.render/update!))
-      (let [files (filter (:filterer options) (perun/get-meta fileset))
+      (let [files (filter (:filterer options) (pm/get-meta fileset))
             updated-files (doall
                            (for [{:keys [path] :as file} files]
                              (let [entry         (merge meta file)
-                                   render-data   {:meta    (perun/get-global-meta fileset)
+                                   render-data   {:meta    (pm/get-global-meta fileset)
                                                   :entries (vec files)
                                                   :entry   entry}
                                    html          (render-in-pod @render-pod renderer render-data)
@@ -469,7 +470,7 @@
                                (perun/create-file tmp page-filepath html)
                                entry)))]
         (perun/report-info "render" "rendered %s pages" (count files))
-        (perun/merge-meta (commit fileset tmp) updated-files)))))
+        (pm/merge-meta (commit fileset tmp) updated-files)))))
 
 (def ^:private +collection-defaults+
   {:out-dir "public"
@@ -516,10 +517,10 @@
               (pod/with-call-in @render-pod
                 (io.perun.render/update!))
 
-              (let [files          (perun/get-meta fileset)
+              (let [files          (pm/get-meta fileset)
                     filtered-files (filter (:filterer options) files)
                     grouped-files  (group-by (:groupby options) filtered-files)
-                    global-meta    (perun/get-global-meta fileset)
+                    global-meta    (pm/get-global-meta fileset)
                     new-files      (doall
                                     (map
                                       (fn [[page page-files]]
@@ -540,7 +541,7 @@
                                             new-entry)))
                                       grouped-files))
                     updated-files    (apply conj files (trace :io.perun/collection new-files))
-                    updated-fileset  (perun/set-meta fileset updated-files)]
+                    updated-fileset  (pm/set-meta fileset updated-files)]
                   (commit updated-fileset tmp))))))
 
 (deftask inject-scripts

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -2,42 +2,8 @@
   "Utilies which can be used in base JVM and pods."
   (:require [clojure.java.io         :as io]
             [clojure.string          :as string]
-            [boot.core               :as boot]
             [boot.from.io.aviso.ansi :as ansi]
             [boot.util               :as u]))
-
-(def +meta-key+ :io.perun)
-
-(defn get-meta
-  "Return metadata on files. Files metadata is a list.
-   Internally it's stored as a map indexed by `:path`"
-  [fileset]
-  (keep +meta-key+ (vals (:tree fileset))))
-
-(defn key-meta [data]
-  (into {} (for [d data] [(:path d) d])))
-
-(defn set-meta
-  "Update `+meta-key+` metadata for files in `data` and return updated fileset"
-  [fileset data]
-  (boot/add-meta fileset (into {} (for [d data] [(:path d) {+meta-key+ d}]))))
-
-(defn merge-meta* [m1 m2]
-  (vals (merge-with merge (key-meta m1) (key-meta m2))))
-
-(defn merge-meta [fileset data]
-  (set-meta fileset (merge-meta* (get-meta fileset) data)))
-
-(def +global-meta-key+ :io.perun.global)
-
-(defn get-global-meta
-  "Return global metadata that is related to the whole project
-   and all files. Global metadata is a map"
-  [fileset]
-  (-> fileset meta +global-meta-key+))
-
-(defn set-global-meta [fileset data]
-  (vary-meta fileset assoc +global-meta-key+ data))
 
 (defn report-info [task msg & args]
   (apply u/info

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -2,6 +2,7 @@
   "Utilies which can be used in base JVM and pods."
   (:require [clojure.java.io         :as io]
             [clojure.string          :as string]
+            [boot.core               :as boot]
             [boot.from.io.aviso.ansi :as ansi]
             [boot.util               :as u]))
 
@@ -11,7 +12,7 @@
   "Return metadata on files. Files metadata is a list.
    Internally it's stored as a map indexed by `:path`"
   [fileset]
-  (-> fileset meta +meta-key+ vals))
+  (keep +meta-key+ (vals (:tree fileset))))
 
 (defn key-meta [data]
   (into {} (for [d data] [(:path d) d])))
@@ -19,7 +20,7 @@
 (defn set-meta
   "Update `+meta-key+` metadata for the fileset and return updates fileset"
   [fileset data]
-  (vary-meta fileset assoc +meta-key+ (key-meta data)))
+  (boot/add-meta fileset (into {} (for [d data] [(:path d) {+meta-key+ d}]))))
 
 (defn merge-meta* [m1 m2]
   (vals (merge-with merge (key-meta m1) (key-meta m2))))

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -18,7 +18,7 @@
   (into {} (for [d data] [(:path d) d])))
 
 (defn set-meta
-  "Update `+meta-key+` metadata for files in `data` and return updates fileset"
+  "Update `+meta-key+` metadata for files in `data` and return updated fileset"
   [fileset data]
   (boot/add-meta fileset (into {} (for [d data] [(:path d) {+meta-key+ d}]))))
 

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -18,7 +18,7 @@
   (into {} (for [d data] [(:path d) d])))
 
 (defn set-meta
-  "Update `+meta-key+` metadata for the fileset and return updates fileset"
+  "Update `+meta-key+` metadata for files in `data` and return updates fileset"
   [fileset data]
   (boot/add-meta fileset (into {} (for [d data] [(:path d) {+meta-key+ d}]))))
 

--- a/src/io/perun/meta.clj
+++ b/src/io/perun/meta.clj
@@ -1,0 +1,36 @@
+(ns io.perun.meta
+  "Utilies for dealing with perun metadata"
+  (:require [boot.core :as boot]))
+
+(def +meta-key+ :io.perun)
+
+(defn get-meta
+  "Return metadata on files. Files metadata is a list.
+   Internally it's stored as a map indexed by `:path`"
+  [fileset]
+  (keep +meta-key+ (vals (:tree fileset))))
+
+(defn key-meta [data]
+  (into {} (for [d data] [(:path d) d])))
+
+(defn set-meta
+  "Update `+meta-key+` metadata for files in `data` and return updated fileset"
+  [fileset data]
+  (boot/add-meta fileset (into {} (for [d data] [(:path d) {+meta-key+ d}]))))
+
+(defn merge-meta* [m1 m2]
+  (vals (merge-with merge (key-meta m1) (key-meta m2))))
+
+(defn merge-meta [fileset data]
+  (set-meta fileset (merge-meta* (get-meta fileset) data)))
+
+(def +global-meta-key+ :io.perun.global)
+
+(defn get-global-meta
+  "Return global metadata that is related to the whole project
+   and all files. Global metadata is a map"
+  [fileset]
+  (-> fileset meta +global-meta-key+))
+
+(defn set-global-meta [fileset data]
+  (vary-meta fileset assoc +global-meta-key+ data))


### PR DESCRIPTION
The most immediate benefit of this change is that `markdown` no longer needs to manually track files removed from the fileset between invocations. As a result, `markdown` is shorter and simpler, and the same will be true of any future input parsing tasks.

Some discussion is necessary on this one. There is a problem about how to deal with requiring `boot` in `io.perun.core`. The problem arises when a project doesn't depend on boot itself, and then executes a fn in a pod, and the fn's namespace requires `io.perun.core`. The pod can't find boot.core, and so, boom. Options:
 - Make projects depend on boot
 - Add boot to pod dependencies when pod namespaces require io.perun.core
 - Split the boot-using parts of io.perun.core into a separate namespace, and don't require that namespace from a pod
 - Something else?

I prefer the second option, but not strongly, and I'm not sure if there are performance considerations with adding more dependencies to pods.