### PR TITLE
Merge filedata

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -56,7 +56,7 @@
 (defn add-filedata [tmp-files]
   (pod/with-call-in @filedata-pod
     (io.perun.filedata/filedatas
-     ~(vec (map (juxt boot/tmp-path #(.getPath (boot/tmp-file %)) perun/+meta-key+) tmp-files)))))
+     ~(vec (map (juxt boot/tmp-path #(.getPath (boot/tmp-file %)) pm/+meta-key+) tmp-files)))))
 
 (deftask base
   "Add some basic information to the perun metadata and

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -52,7 +52,8 @@
 
 (defn add-filedata [tmp-files]
   (pod/with-call-in @filedata-pod
-    (io.perun.filedata/filedatas ~(vec (map (juxt boot/tmp-path #(.getPath (boot/tmp-file %))) tmp-files)))))
+    (io.perun.filedata/filedatas
+     ~(vec (map (juxt boot/tmp-path #(.getPath (boot/tmp-file %)) perun/+meta-key+) tmp-files)))))
 
 (deftask base
   "Add some basic information to the perun metadata and

--- a/src/io/perun/filedata.clj
+++ b/src/io/perun/filedata.clj
@@ -4,22 +4,24 @@
             [io.perun.core :as perun]
             [pantomime.mime :as pm]))
 
-(defn filedata [[tmp-path full-path]]
+(defn filedata [[tmp-path full-path metadata]]
   (let [io-file   (io/file full-path)
         filename  (.getName io-file)
         mime-type (pm/mime-type-of io-file)
         file-type (first (string/split mime-type #"/"))]
-    {; filename with extension
-     :filename       filename
-     ; filename without extension
-     :short-filename (perun/filename filename)
-     :path           tmp-path
-     :mime-type      mime-type
-     :file-type      file-type
-     ; parent folder path
-     :parent-path    (perun/parent-path tmp-path filename)
-     :full-path      full-path
-     :extension      (perun/extension filename)}))
+    (merge
+     metadata
+     {; filename with extension
+      :filename       filename
+      ; filename without extension
+      :short-filename (perun/filename filename)
+      :path           tmp-path
+      :mime-type      mime-type
+      :file-type      file-type
+      ; parent folder path
+      :parent-path    (perun/parent-path tmp-path filename)
+      :full-path      full-path
+      :extension      (perun/extension filename)})))
 
 (defn filedatas [tmp-files]
   (map filedata tmp-files))


### PR DESCRIPTION
If you're wondering if I have a series of branches just waiting to be pull requests... well, yes, I do.  I even wiki'd it to keep track, if you're interested: https://github.com/bhagany/perun/wiki

Anyway, this is a simple change.  I was always surprised that `add-filedata` overwrites all of the existing metadata for the files it touches.  This PR merges the metadata instead, so that you don't have to worry about having tasks touch the same file and deleting stuff you expected to be there.  I can't think of any use cases that this would break, but if you have some, I'd be interested to hear.