### PR TITLE
Content pipeline

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@ All posts have a path which is used as a key to identify the post.
 - **:has-content** Flag indicating that this file contains page content
     - Set by input parsing tasks (like `markdown`) on output files
     - Passed through by rendering tasks
-- **:original-content** Contains the content from the original parsing task
+- **:original-path** The path for the input file from which this entry is descended
     - Set by input parsing tasks (like `markdown`) on output files
     - Passed through by rendering tasks
 - **:parsed** Contains the parsed file content

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,13 +27,22 @@ set for the tasks using task options.
 
 ## Post metadata
 
-All posts have a filename which is used as a key to identify the post.
+All posts have a path which is used as a key to identify the post.
 
 - **:title**
     - Required by: *atom-feed*
     - Used by: *rss* either this or description is required
 - **:content** The post content
-    - Set by: *markdown*
+    - Populated from file content
+    - Only set in the `:entry` value of the map passed to `renderer` functions
+- **:has-content** Flag indicating that this file contains page content
+    - Set by input parsing tasks (like `markdown`) on output files
+    - Passed through by rendering tasks
+- **:original-content** Contains the content from the original parsing task
+    - Set by input parsing tasks (like `markdown`) on output files
+    - Passed through by rendering tasks
+- **:parsed** Contains the parsed file content
+    - Set by input parsing tasks (like `markdown`) on input files
 - **:description**
     - Used by: *rss* either this or title is required
 - **:slug**

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -450,10 +450,12 @@
             files         (->> fileset
                                perun/get-meta
                                (filter (:filterer options))
-                               (map #(let [f (boot/tmp-get fileset (:original-path %))
-                                           oc (or (-> f perun/+meta-key+ :parsed)
-                                                  (-> f boot/tmp-file slurp))]
-                                       (assoc % :original-content oc))))]
+                               (map #(let [file (if-let [original-path (:original-path %)]
+                                                  (boot/tmp-get fileset original-path)
+                                                  (boot/tmp-get fileset (:path %)))
+                                           content (or (-> file perun/+meta-key+ :parsed)
+                                                       (-> file boot/tmp-file slurp))]
+                                       (assoc % :content content))))]
         (perun/assert-base-url (:base-url options))
         (pod/with-call-in @pod
           (io.perun.atom/generate-atom ~(.getPath tmp) ~files ~(dissoc options :filterer)))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -152,8 +152,12 @@
                                                        :full-path :mime-type :original))]
                                  (perun/create-file tmp page-filepath parsed)
                                  entry)))
+            input-metadata* (map #(-> %
+                                      (dissoc :include-rss)
+                                      (dissoc :include-atom))
+                                 input-metadata)
             final-metadata (perun/merge-meta* (perun/get-meta @prev-fs)
-                                              (concat input-metadata output-metadata))
+                                              (concat input-metadata* output-metadata))
             new-fs (-> fileset
                        (commit tmp)
                        (perun/set-meta final-metadata))]

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -532,6 +532,7 @@
       (let [render-paths (render-paths-fn fileset options)
             new-metadata (render-to-paths render-paths (:renderer options) tmp tracer)
             rm-files (keep #(boot/tmp-get fileset (-> % :entry :path)) (vals render-paths))]
+        (perun/report-debug "render-pre-wrap" "removing files" rm-files)
         (-> fileset
             (boot/rm rm-files)
             (commit tmp)

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -180,7 +180,8 @@
 
    This task will look for files ending with `md` or `markdown`
    and add a `:parsed` key to their metadata containing the
-   HTML resulting from processing markdown file's content"
+   HTML resulting from processing markdown file's content. Also
+   writes an HTML file that contains the same content as `:parsed`"
   [m meta    META edn "metadata to set on each entry; keys here will be overridden by metadata in each file"
    o options OPTS edn "options to be passed to the markdown parser"]
   (let [pod     (create-pod markdown-deps)

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -431,7 +431,7 @@
       (let [global-meta   (pm/get-global-meta fileset)
             options       (merge +rss-defaults+ global-meta *opts*)
             files         (->> fileset
-                               boot/user-files
+                               boot/output-files
                                (boot/by-ext (:extensions options))
                                (keep pm/+meta-key+)
                                (filter (:filterer options)))]

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -145,6 +145,7 @@
                                (let [page-filepath (string/replace path #"(?i).[a-z]+$" ".html")
                                      entry (-> entry*
                                                (assoc :has-content true)
+                                               (assoc :original-content parsed)
                                                (assoc :path page-filepath)
                                                (assoc :filename (string/replace filename
                                                                                 #"(?i).[a-z]+$" ".html"))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -81,7 +81,7 @@
     (let [pod (create-pod images-dimensions-deps)
           files (->> fileset
                      boot/user-files
-                     (boot/by-ext ["png" "jpeg" "jpg"])
+                     (boot/by-ext [".png" ".jpeg" ".jpg"])
                      add-filedata
                      (trace :io.perun/images-dimensions))
           updated-files (pod/with-call-in @pod
@@ -107,7 +107,7 @@
           pod (create-pod images-resize-deps)
           files (->> fileset
                      boot/user-files
-                     (boot/by-ext ["png" "jpeg" "jpg"])
+                     (boot/by-ext [".png" ".jpeg" ".jpg"])
                      add-filedata
                      (trace :io.perun/images-resize))
           updated-files (pod/with-call-in @pod
@@ -185,7 +185,7 @@
         options (merge +markdown-defaults+ *opts*)]
     (content-pre-wrap
      (fn [files] `(io.perun.markdown/parse-markdown ~files ~options))
-     ["md" "markdown"]
+     [".md" ".markdown"]
      :io.perun/markdown
      pod)))
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -209,14 +209,11 @@
          (perun/report-info "global-metadata" "read global metadata from %s" meta-file)
          (pm/set-global-meta fileset global-meta))))
 
-(defn- set-content-from-meta
-  [fileset meta]
-  (let [content (->> meta
-                     :path
-                     (boot/tmp-get fileset)
-                     boot/tmp-file
-                     slurp)]
-    (assoc meta :content content)))
+(defn- get-meta-contents
+  [fileset filterer]
+  (->> (vals (:tree fileset))
+       (filter (comp filterer pm/+meta-key+))
+       (map (juxt pm/+meta-key+ (comp slurp boot/tmp-file)))))
 
 (def ^:private ttr-deps
   '[[time-to-read "0.1.0"]])
@@ -230,15 +227,12 @@
   (let [pod     (create-pod ttr-deps)
         options (merge +ttr-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files (->> fileset
-                       pm/get-meta
-                       (filter (:filterer options))
-                       (map #(set-content-from-meta fileset %)))
-            updated-files (trace :io.perun/ttr
+      (let [meta-contents (get-meta-contents fileset (:filterer options))
+            updated-metas (trace :io.perun/ttr
                                  (pod/with-call-in @pod
-                                   (io.perun.ttr/calculate-ttr ~files)))]
-        (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-files))
-        (pm/set-meta fileset updated-files)))))
+                                   (io.perun.ttr/calculate-ttr ~meta-contents)))]
+        (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-metas))
+        (pm/set-meta fileset updated-metas)))))
 
 (def ^:private +word-count-defaults+
   {:filterer :has-content})
@@ -246,18 +240,16 @@
 (deftask word-count
   "Count words in each file. Add `:word-count` key to the files' meta"
   [_ filterer FILTER code "predicate to use for selecting entries (default: `:has-content`)"]
-  (let [pod (create-pod ttr-deps)
-        options (merge +word-count-defaults+ *opts*)]
+  (let [options (merge +word-count-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
-      (let [files (->> fileset
-                       pm/get-meta
-                       (filter (:filterer options))
-                       (map #(set-content-from-meta fileset %)))
-            updated-files (trace :io.perun/word-count
-                                 (pod/with-call-in @pod
-                                   (io.perun.word-count/count-words ~files)))]
-        (perun/report-debug "word-count" "counted words" (map :word-count updated-files))
-        (pm/set-meta fileset updated-files)))))
+      (let [meta-contents (get-meta-contents fileset (:filterer options))
+            updated-metas (trace :io.perun/word-count
+                                 ;; word count doesn't have any special dependencies,
+                                 ;; so we can just reuse the filedata pod
+                                 (pod/with-call-in @filedata-pod
+                                   (io.perun.word-count/count-words ~meta-contents)))]
+        (perun/report-debug "word-count" "counted words" (map :word-count updated-metas))
+        (pm/set-meta fileset updated-metas)))))
 
 (def ^:private gravatar-deps
   '[[gravatar "0.1.0"]])
@@ -465,20 +457,20 @@
     (boot/with-pre-wrap fileset
       (let [global-meta   (pm/get-global-meta fileset)
             options       (merge +atom-defaults+ global-meta *opts*)
-            files         (->> fileset
+            meta-contents (->> fileset
                                boot/output-files
                                (boot/by-ext (:extensions options))
-                               (keep pm/+meta-key+)
-                               (filter (:filterer options))
-                               (map #(let [file (if-let [original-path (:original-path %)]
+                               (filter (comp (:filterer options) pm/+meta-key+))
+                               (map #(let [meta (pm/+meta-key+ %)
+                                           file (if-let [original-path (:original-path meta)]
                                                   (boot/tmp-get fileset original-path)
-                                                  (boot/tmp-get fileset (:path %)))
+                                                  %)
                                            content (or (-> file pm/+meta-key+ :parsed)
                                                        (-> file boot/tmp-file slurp))]
-                                       (assoc % :content content))))]
+                                       [meta content])))]
         (perun/assert-base-url (:base-url options))
         (pod/with-call-in @pod
-          (io.perun.atom/generate-atom ~(.getPath tmp) ~files ~(dissoc options :filterer)))
+          (io.perun.atom/generate-atom ~(.getPath tmp) ~meta-contents ~(dissoc options :filterer)))
         (commit fileset tmp)))))
 
 (defn- assert-renderer [sym]
@@ -519,7 +511,7 @@
           (for [[path render-data] data]
             (let [content (render-in-pod @render-pod renderer render-data)]
               (perun/create-file tmp path content)
-              (assoc (:entry render-data)
+              (assoc (dissoc (:entry render-data) :content)
                      :path path
                      :has-content true))))))
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -155,13 +155,14 @@
                                                   :path page-filepath
                                                   :filename (string/replace filename
                                                                             ext-pattern ".html"))
-                                           (dissoc :parsed :extension :file-type :full-path
-                                                   :mime-type :original))]
+                                           (dissoc :parsed :original))]
                              (perun/create-file tmp page-filepath parsed)
                              entry)))
-            new-fs (-> input-fs
-                       (commit tmp)
-                       (pm/set-meta output-meta))]
+            new-fs* (-> input-fs
+                        (commit tmp)
+                        (pm/set-meta output-meta))
+            filedata (add-filedata (boot/by-path (map :path output-meta) (boot/ls new-fs*)))
+            new-fs (pm/set-meta new-fs* filedata)]
         (reset! prev-fs new-fs)
         new-fs))))
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -148,7 +148,7 @@
                                                (assoc :path page-filepath)
                                                (assoc :filename (string/replace filename
                                                                                 #"(?i).[a-z]+$" ".html"))
-                                               (dissoc :parsed :extension :file-type :parent-path
+                                               (dissoc :parsed :extension :file-type
                                                        :full-path :mime-type :original))]
                                  (perun/create-file tmp page-filepath parsed)
                                  entry)))

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -218,11 +218,11 @@
   '[[time-to-read "0.1.0"]])
 
 (def ^:private +ttr-defaults+
-  {:filterer :content})
+  {:filterer :has-content})
 
 (deftask ttr
   "Calculate time to read for each file. Add `:ttr` key to the files' meta"
-  [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `:has-content`)"]
   (let [pod     (create-pod ttr-deps)
         options (merge +ttr-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
@@ -234,11 +234,11 @@
         (perun/set-meta fileset updated-files)))))
 
 (def ^:private +word-count-defaults+
-  {:filterer :content})
+  {:filterer :has-content})
 
 (deftask word-count
   "Count words in each file. Add `:word-count` key to the files' meta"
-  [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `:has-content`)"]
   (let [pod (create-pod ttr-deps)
         options (merge +word-count-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
@@ -253,13 +253,13 @@
   '[[gravatar "0.1.0"]])
 
 (def ^:private +gravatar-defaults+
-  {:filterer :content})
+  {:filterer :has-content})
 
 (deftask gravatar
   "Find gravatar urls using emails"
   [s source-key SOURCE-PROP kw "email property used to lookup gravatar url"
    t target-key TARGET-PROP kw "property name to store gravatar url"
-   _ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
+   _ filterer FILTER code "predicate to use for selecting entries (default: `:has-content`)"]
   (let [pod (create-pod gravatar-deps)
         options (merge +gravatar-defaults+ *opts*)]
     (boot/with-pre-wrap fileset
@@ -283,11 +283,11 @@
       (perun/set-meta fileset updated-files))))
 
 (def ^:private +build-date-defaults+
-  {:filterer :content})
+  {:filterer :has-content})
 
 (deftask build-date
   "Add :date-build attribute to each file metadata and also to the global meta"
-  [_ filterer FILTER code "predicate to use for selecting entries (default: `:content`)"]
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `:has-content`)"]
   (boot/with-pre-wrap fileset
     (let [options         (merge +build-date-defaults+ *opts*)
           files           (filter (:filterer options) (perun/get-meta fileset))
@@ -408,7 +408,7 @@
 (deftask rss
   "Generate RSS feed"
   [f filename    FILENAME    str  "generated RSS feed filename"
-   _ filterer    FILTER      code "predicate to use for selecting entries (default: `:content`)"
+   _ filterer    FILTER      code "predicate to use for selecting entries (default: `:include-rss`)"
    o out-dir     OUTDIR      str  "the output directory"
    t site-title  TITLE       str  "feed title"
    p description DESCRIPTION str  "feed description"
@@ -436,7 +436,7 @@
 (deftask atom-feed
   "Generate Atom feed"
   [f filename    FILENAME    str  "generated Atom feed filename"
-   _ filterer    FILTER      code "predicate to use for selecting entries (default: `:content`)"
+   _ filterer    FILTER      code "predicate to use for selecting entries (default: `:include-atom`)"
    o out-dir     OUTDIR      str  "the output directory"
    t site-title  TITLE       str  "feed title"
    s subtitle    SUBTITLE    str  "feed subtitle"

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -147,13 +147,14 @@
             input-meta (meta-by-ext input-fs file-exts)
             output-meta (doall
                          (for [{:keys [path parsed filename] :as entry*} input-meta]
-                           (let [page-filepath (string/replace path #"(?i).[a-z]+$" ".html")
+                           (let [ext-pattern (re-pattern (str "(" (string/join "|" file-exts) ")$"))
+                                 page-filepath (string/replace path ext-pattern ".html")
                                  entry (-> entry*
                                            (assoc :has-content true
                                                   :original-path path
                                                   :path page-filepath
                                                   :filename (string/replace filename
-                                                                            #"(?i).[a-z]+$" ".html"))
+                                                                            ext-pattern ".html"))
                                            (dissoc :parsed :extension :file-type :full-path
                                                    :mime-type :original))]
                              (perun/create-file tmp page-filepath parsed)

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -582,7 +582,7 @@
   "Produces path maps of the shape required by `render-to-paths`, based
   on the provided `fileset` and `options`."
   [task-name fileset options]
-  (let [global-meta (perun/get-global-meta fileset)
+  (let [global-meta (pm/get-global-meta fileset)
         grouper (:grouper options)]
     (->> fileset
          pm/get-meta

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -115,6 +115,10 @@
       (commit fileset tmp))))
 
 (defn content-pre-wrap
+  "Wrapper for input parsing tasks. Calls `parse-form` on new or changed
+  files with extensions in `file-exts`, adds `tracer` to `:io.perun/trace`
+  and writes html files for subsequent tasks to process, if desired. Pass
+  `pod` if one is needed for parsing"
   [parse-form file-exts tracer & [pod]]
   (let [tmp     (boot/tmp-dir!)
         prev-fs (atom nil)]
@@ -495,6 +499,8 @@
             (perun/merge-meta new-metadata))))))
 
 (defn- make-path
+  "Encapsulates common logic for deciding where to write a file,
+  based on the source's metadata"
   [out-dir permalink path]
   (perun/create-filepath
    out-dir

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -115,7 +115,7 @@
       (commit fileset tmp))))
 
 (defn content-pre-wrap
-  [parse-form file-exts tracer options]
+  [parse-form file-exts tracer & [pod]]
   (let [tmp     (boot/tmp-dir!)
         prev-fs (atom nil)]
     (boot/with-pre-wrap fileset
@@ -124,7 +124,7 @@
                                (boot/by-ext file-exts)
                                add-filedata)
             input-metadata (->>
-                            (if-let [pod (:pod options)]
+                            (if pod
                               (pod/with-call-in @pod ~(parse-form changed-files))
                               (eval (parse-form changed-files)))
                             (trace tracer))
@@ -183,12 +183,12 @@
   [m meta    META edn "metadata to set on each entry; keys here will be overridden by metadata in each file"
    o options OPTS edn "options to be passed to the markdown parser"]
   (let [pod     (create-pod markdown-deps)
-        options (merge +markdown-defaults+ {:pod pod} *opts*)]
+        options (merge +markdown-defaults+ *opts*)]
     (content-pre-wrap
-     (fn [files] `(io.perun.markdown/parse-markdown ~files ~(dissoc options :pod)))
+     (fn [files] `(io.perun.markdown/parse-markdown ~files ~options))
      ["md" "markdown"]
      :io.perun/markdown
-     options)))
+     pod)))
 
 (deftask global-metadata
   "Read global metadata from `perun.base.edn` or configured file.

--- a/src/io/perun/atom.clj
+++ b/src/io/perun/atom.clj
@@ -44,7 +44,7 @@
           [:name (:author global-metadata)]
           [:email (:author-email global-metadata)]])
 
-       (for [{:keys [uuid canonical-url content title author author-email] :as post} (take 10 posts)
+       (for [{:keys [uuid canonical-url original-content title author author-email] :as post} (take 10 posts)
              :let [author (or author (:author global-metadata))
                    author-email (or author-email (:author-email global-metadata))]]
          (do
@@ -58,7 +58,7 @@
             [:published (iso-datetime (published post))]
             [:updated (iso-datetime (updated post))]
             ;; FIXME: plain text on xml:base property
-            [:content {:type "html"} (str content)]
+            [:content {:type "html"} (str original-content)]
             [:author
              [:name author]
              (if author-email [:email author-email])]

--- a/src/io/perun/atom.clj
+++ b/src/io/perun/atom.clj
@@ -32,8 +32,7 @@
        [:link {:href (str base-url filename) :rel "self"}]
        [:link {:href base-url :type "text/html"}]
        [:updated (->> (take 10 posts)
-                      (map updated)
-                      (map iso-datetime)
+                      (map (comp iso-datetime updated first))
                       sort
                       reverse
                       first)]
@@ -44,7 +43,7 @@
           [:name (:author global-metadata)]
           [:email (:author-email global-metadata)]])
 
-       (for [{:keys [uuid canonical-url content title author author-email] :as post} (take 10 posts)
+       (for [[{:keys [uuid canonical-url title author author-email] :as post} content] (take 10 posts)
              :let [author (or author (:author global-metadata))
                    author-email (or author-email (:author-email global-metadata))]]
          (do

--- a/src/io/perun/atom.clj
+++ b/src/io/perun/atom.clj
@@ -44,7 +44,7 @@
           [:name (:author global-metadata)]
           [:email (:author-email global-metadata)]])
 
-       (for [{:keys [uuid canonical-url original-content title author author-email] :as post} (take 10 posts)
+       (for [{:keys [uuid canonical-url content title author author-email] :as post} (take 10 posts)
              :let [author (or author (:author global-metadata))
                    author-email (or author-email (:author-email global-metadata))]]
          (do
@@ -58,7 +58,7 @@
             [:published (iso-datetime (published post))]
             [:updated (iso-datetime (updated post))]
             ;; FIXME: plain text on xml:base property
-            [:content {:type "html"} (str original-content)]
+            [:content {:type "html"} (str content)]
             [:author
              [:name author]
              (if author-email [:email author-email])]

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -55,7 +55,7 @@
   (let [file-content (-> file :full-path io/file slurp)
         md-metadata (merge (:meta options) (yaml/parse-file-metadata file-content))
         html (markdown-to-html file-content (:options options))]
-    (merge md-metadata {:content html} file)))
+    (merge md-metadata {:parsed html} file)))
 
 (defn parse-markdown [markdown-files options]
   (let [updated-files (doall (map #(process-file % options) markdown-files))]

--- a/src/io/perun/meta.clj
+++ b/src/io/perun/meta.clj
@@ -4,11 +4,16 @@
 
 (def +meta-key+ :io.perun)
 
+(defn meta-from-file
+  [tmpfile]
+  (when-let [meta (+meta-key+ tmpfile)]
+    (assoc meta :path (:path tmpfile))))
+
 (defn get-meta
   "Return metadata on files. Files metadata is a list.
    Internally it's stored as a map indexed by `:path`"
   [fileset]
-  (keep +meta-key+ (vals (:tree fileset))))
+  (keep meta-from-file (vals (:tree fileset))))
 
 (defn key-meta [data]
   (into {} (for [d data] [(:path d) d])))
@@ -16,7 +21,7 @@
 (defn set-meta
   "Update `+meta-key+` metadata for files in `data` and return updated fileset"
   [fileset data]
-  (boot/add-meta fileset (into {} (for [d data] [(:path d) {+meta-key+ d}]))))
+  (boot/add-meta fileset (into {} (for [d data] [(:path d) {+meta-key+ (dissoc d :path)}]))))
 
 (defn merge-meta* [m1 m2]
   (vals (merge-with merge (key-meta m1) (key-meta m2))))

--- a/src/io/perun/ttr.clj
+++ b/src/io/perun/ttr.clj
@@ -2,12 +2,11 @@
   (:require [io.perun.core     :as perun]
             [time-to-read.core :as time-to-read]))
 
-(defn add-ttr [file]
-  (if-let [content (:content file)]
-    (assoc file :ttr (time-to-read/estimate-for-text content))
-    file))
+(defn add-ttr [[meta content]]
+  (when content
+    (assoc meta :ttr (time-to-read/estimate-for-text content))))
 
-(defn calculate-ttr [files]
-  (let [updated-files (map add-ttr files)]
-    (perun/report-info "ttr" "added TTR to %s files" (count updated-files))
-    updated-files))
+(defn calculate-ttr [meta-contents]
+  (let [metas (keep add-ttr meta-contents)]
+    (perun/report-info "ttr" "added TTR to %s files" (count metas))
+    metas))

--- a/src/io/perun/word_count.clj
+++ b/src/io/perun/word_count.clj
@@ -1,12 +1,11 @@
 (ns io.perun.word-count
-  (:require [io.perun.core     :as perun]))
+  (:require [io.perun.core :as perun]))
 
-(defn add-word-count [file]
-  (if-let [content (:content file)]
-    (assoc file :word-count (count (clojure.string/split content #"\s")))
-    file))
+(defn add-word-count [[meta content]]
+  (when content
+    (assoc meta :word-count (count (clojure.string/split content #"\s")))))
 
-(defn count-words [files]
-  (let [updated-files (map add-word-count files)]
-    (perun/report-info "word-count" "added word-count to %s files" (count updated-files))
-    updated-files))
+(defn count-words [meta-contents]
+  (let [metas (map add-word-count meta-contents)]
+    (perun/report-info "word-count" "added word-count to %s files" (count metas))
+    metas))

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -18,6 +18,12 @@
   (or (some #{val} (-> file pm/+meta-key+ key))
       (contains? (-> file pm/+meta-key+ key) val)))
 
+(deftask prn-meta-key
+  [p path PATH str "path of the file to test"
+   k key  KEY  kw  "the key to prn"]
+  (boot/with-pass-thru fileset
+    (->> path (boot/tmp-get fileset) pm/+meta-key+ key prn)))
+
 (deftask key-test
   [p path PATH str "path of the file to test"
    k key  KEY  kw  "the key to test"

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -122,7 +122,9 @@ This be ___markdown___.")
   (str "<body>" (:content (:entry data)) "</body>"))
 
 (deftesttask markdown-test []
-  (comp (add-txt-file :path "2017-01-01-test.md" :content md-content)
+  (comp (p/collection :renderer 'io.perun-test/render) ;; test #77, collection works without input files
+
+        (add-txt-file :path "2017-01-01-test.md" :content md-content)
         (boot/with-pre-wrap fileset
           (pm/set-global-meta fileset {:base-url "http://example.com/"
                                        :site-title "Test Title"


### PR DESCRIPTION
Credit to @MartyGentillon for the ideas that led to this PR (see the conversation on https://github.com/hashobject/perun/pull/109). This is the big change most of my past PR's have been leading up to - it meets the following goals:

- support existing usage patterns
- allow more possible compositions of perun tasks
- allow 3rd party tasks to be interposed with perun tasks more easily
- resolve weirdness about the `:content` key
- abstract content parsing similarly to the rendering abstraction (aka `render-pre-wrap`)

The central conceptual change here is completing the transition from a more metadata-based approach to a more file-based approach. The first major step here was to store file metadata on boot's TmpFiles, rather than in fileset metadata. This allows us to move or delete files without having to maintain their metadata separately. The second (and last) step, is to do away with the `:content` metadata key in favor of writing and manipulating TmpFiles, and using the content of the files, rather than maintaining that information in metadata. This allows any task to manipulate perun's final output, without that task having to be actually aware of perun and its metadata conventions.

For example, I know some here are fans of Tachyons (http://tachyons.io/). With this change, it would be possible to write a _general_ `tachyons` task that manipulates file content and can be used with or without perun. To explain with code,

```clojure
(deftask build
  (comp (p/markdown)
        (tachyons) ;; <-- unaware of perun
        (p/render :renderer 'your.ns/render)))
```

Before this change, the `tachyons` task would need to know about and manipulate perun's `:content` key in order to get what you wanted in `perun/render`, but now it can just change the file itself and ignore perun.

In addition to being more composable with 3rd party tasks, the change from metadata content to file content also allows perun's task to be composed with each other in ways that weren't possible before. Here's a real-life example from the `build.boot` for my blog\*:

```clojure
(deftask urls
  "Helper task for encapsulating all url generation stuff"
  [_ filterer FILTERER code "predicate to use for selecting entries (default: `:has-content`)"]
  (let [filterer (or filterer :has-content)]
    (comp (p/slug :slug-fn slugify-filename :filterer filterer)
          (p/permalink :permalink-fn permalinkify :filterer filterer)
          (p/canonical-url :filterer filterer))))

(deftask build
  "Build nicerthantriton.com"
  [t tier TIER kw "The tier we're building for"]
  (comp (p/global-metadata)
        (set-tier :val tier)
        (p/markdown :options {:extensions {:smarts true}})  ;; writes an .html file per .md file
        (urls)
        (p/collection :renderer 'nicerthantriton.core/index ;; produces an index page based on the output from `markdown`
                      :filterer post?
                      :meta {:derived true})
        (p/assortment :renderer 'nicerthantriton.core/topic ;; not in master yet, you can ignore it
                      :filterer post?
                      :grouper tagify
                      :meta {:derived true})
        (urls :filterer :derived)
        (recent-posts)                                      ;; These two set some global metadata based on .html files
        (topics)                                            ;; that exist at this point in the pipeline - you can ignore
        (p/render :renderer 'nicerthantriton.core/post      ;; Wraps post content with things like tags and publish date
                  :filterer post?)
        (p/render :renderer 'nicerthantriton.core/page)     ;; Wraps _all_ .html files with the things that are common to every page
        (p/atom-feed :filterer post?)))
```

Some interesting things about this:
- `collection` can be called before `render`, and the result can be treated the same as files generated by `markdown`
- multiple `render` tasks can be used to progressively build up pages
- the original usage pattern is still supported - that is, you can still use a single `render` step, and `collection` could render a finished page in one pass, if that works best for you.

I'm very interested in any feedback you have, and in particular, if there are any use cases that are currently supported in master, but unsupported here.

Lastly, I would like you all to know that every time I think about this branch, my brain sings "It's the content pipeline" to the tune of "It's the final countdown". You're welcome.

\* There's no content on the blog yet. Working on it.