### PR TITLE
Fix #133, close #105, close #106 - decompose `markdown`

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -280,11 +280,11 @@
   "Parse markdown files
 
   This task will look for files ending with `md` or `markdown`
-  and add a `:parsed` key to their metadata containing the
-  HTML resulting from processing markdown file's content. It
-  will not parse YAML metadata at the head of the file. Also
-  writes an HTML file that contains the same content as
-  `:parsed`"
+  and writes an HTML file that contains the result from
+  processing the markdown file's content. It will _not_ parse
+  YAML metadata at the head of the file. Also adds a `:parsed`
+  key to the markdown file's metadata, allowing us not to
+  re-parse the same content later."
   [d out-dir  OUTDIR  str "the output directory"
    m meta     META    edn "metadata to set on each entry; keys here will be overridden by metadata in each file"
    o options  OPTS    edn "options to be passed to the markdown parser"]
@@ -302,10 +302,12 @@
   "Parse markdown files
 
   This task will look for files ending with `md` or `markdown`
-  and add a `:parsed` key to their metadata containing the
-  HTML resulting from processing markdown file's content. It
-  will parse YAML metadata at the head of the file, and add
-  any data found to the output's metadata."
+  and writes an HTML file that contains the result from
+  processing the markdown file's content. It will parse YAML
+  metadata at the head of the file, and add any data found to
+  the output's metadata. Also adds a `:parsed` key to the
+  markdown file's metadata, allowing us not to re-parse the
+  same content later."
   [d out-dir  OUTDIR  str "the output directory"
    m meta     META    edn "metadata to set on each entry; keys here will be overridden by metadata in each file"
    o options  OPTS    edn "options to be passed to the markdown parser"]

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -247,8 +247,7 @@
   '[[circleci/clj-yaml "0.5.5"]])
 
 (def ^:private +yaml-metadata-defaults+
-  {:filterer identity
-   :extensions []})
+  {:extensions []})
 
 (deftask yaml-metadata
   "Parse YAML metadata at the beginning of files
@@ -259,10 +258,10 @@
   with the parsed data added as perun metadata."
   [e extensions EXTENSIONS [str] "extensions of files to include (default: `[]`, aka, all extensions)"]
   (let [pod     (create-pod yaml-metadata-deps)
-        options (merge +yaml-metadata-defaults+ *opts*)]
+        {:keys [extensions] :as options} (merge +yaml-metadata-defaults+ *opts*)]
     (content-pre-wrap
      {:parse-form-fn (fn [metas] `(io.perun.yaml/parse-yaml ~metas))
-      :extensions (:extensions options)
+      :extensions extensions
       :output-extension nil ;; keeps the same extension as the input file
       :tracer :io.perun/yaml-metadata
       :options options

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -226,6 +226,12 @@
    :extensions []})
 
 (deftask yaml-metadata
+  "Parse YAML metadata at the beginning of files
+
+  This task is primarily intended for composing with other tasks.
+  It will extract and parse any YAML data from the beginning of
+  a file, and then overwrite that file with the YAML removed, and
+  with the parsed data added as perun metadata."
   [e extensions EXTENSIONS [str] "extensions of files to include (default: `[]`, aka, all extensions)"]
   (let [pod     (create-pod yaml-metadata-deps)
         options (merge +yaml-metadata-defaults+ *opts*)]
@@ -249,9 +255,10 @@
 (deftask markdown*
   "Parse markdown files
 
-   This task will look for files ending with `md` or `markdown`
-   and add a `:parsed` key to their metadata containing the
-   HTML resulting from processing markdown file's content"
+  This task will look for files ending with `md` or `markdown`
+  and add a `:parsed` key to their metadata containing the
+  HTML resulting from processing markdown file's content. It
+  will not parse YAML metadata at the head of the file."
   [d out-dir  OUTDIR  str "the output directory"
    m meta     META    edn "metadata to set on each entry; keys here will be overridden by metadata in each file"
    o options  OPTS    edn "options to be passed to the markdown parser"]
@@ -268,9 +275,11 @@
 (deftask markdown
   "Parse markdown files
 
-   This task will look for files ending with `md` or `markdown`
-   and add a `:parsed` key to their metadata containing the
-   HTML resulting from processing markdown file's content"
+  This task will look for files ending with `md` or `markdown`
+  and add a `:parsed` key to their metadata containing the
+  HTML resulting from processing markdown file's content. It
+  will parse YAML metadata at the head of the file, and add
+  any data found to the output's metadata."
   [d out-dir  OUTDIR  str "the output directory"
    m meta     META    edn "metadata to set on each entry; keys here will be overridden by metadata in each file"
    o options  OPTS    edn "options to be passed to the markdown parser"]

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -1,6 +1,5 @@
 (ns io.perun.markdown
   (:require [io.perun.core   :as perun]
-            [io.perun.yaml   :as yaml]
             [clojure.java.io :as io])
   (:import [org.pegdown PegDownProcessor Extensions]))
 
@@ -46,16 +45,14 @@
 (defn markdown-to-html [file-content options]
   (let [processor (PegDownProcessor. (extensions-map->int (:extensions options)))]
     (->> file-content
-         yaml/remove-metadata
          char-array
          (.markdownToHtml processor))))
 
 (defn process-file [file options]
   (perun/report-debug "markdown" "processing markdown" (:filename file))
   (let [file-content (-> file :full-path io/file slurp)
-        md-metadata (merge (:meta options) (yaml/parse-file-metadata file-content))
         html (markdown-to-html file-content (:options options))]
-    (merge md-metadata {:parsed html} file)))
+    (merge (:meta options) {:parsed html} file)))
 
 (defn parse-markdown [markdown-files options]
   (let [updated-files (doall (map #(process-file % options) markdown-files))]

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -164,7 +164,7 @@ This --- be ___markdown___.")
         (p/word-count)
         (testing "word-count"
           (value-test :path "public/2017-01-01-test.html"
-                      :value-fn #(meta= %1 %2 :word-count 19)
+                      :value-fn #(meta= %1 %2 :word-count 8)
                       :msg "`word-count` should set `:word-count` metadata"))
 
         (p/gravatar :source-key :email :target-key :gravatar)
@@ -263,7 +263,7 @@ This --- be ___markdown___.")
                       :extensions [".htm"])
         (testing "word-count"
           (value-test :path "hammock/test.htm"
-                      :value-fn #(meta= %1 %2 :word-count 19)
+                      :value-fn #(meta= %1 %2 :word-count 8)
                       :msg "`word-count` should set `:word-count` metadata"))
 
         (p/gravatar :source-key :email


### PR DESCRIPTION
Following @MartyGentillon here: https://github.com/hashobject/perun/pull/106#issuecomment-255893969, this PR pulls `markdown` apart into two separate tasks.  The first parses the yaml header on the file, and the second only parses the markdown.  These two simpler tasks are then recomposed into a new `markdown`.

This will allow users to implement their own markdown pre/post processors with ease, and also make yaml metadata parsing easily available to future content tasks.