### PR TITLE
Only replace necessary characters in injected scripts

### DIFF
--- a/src/io/perun/contrib/inject_scripts.clj
+++ b/src/io/perun/contrib/inject_scripts.clj
@@ -6,7 +6,7 @@
 (defn inject [html scripts]
   (->> scripts
        ;; replace regex special characters
-       (map #(str/replace % #"([\\\.\[\]\{\}\(\)\*\+\-\?\^\$\|])" "\\\\$1"))
+       (map #(str/replace % #"([\\\$])" "\\\\$1"))
        (reduce
         #(.replaceFirst %1 "</body>" (format "<script>%s</script></body>" %2))
         html)))


### PR DESCRIPTION
I belatedly realized that the fix for #145 was dealing with
replacement strings, not regexes, and those have a more limited
set of special characters. So this is a fix for an overzealous fix.