### PR TITLE
Add 200ok.ch as a Perun example page

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Following sites were created with perun and Boot:
  - [www.martinklepsch.org](http://www.martinklepsch.org/). See [build.boot](https://github.com/martinklepsch/martinklepsch.org/blob/master/build.boot)
  - [presumably.de](https://presumably.de/). See [build.boot](https://github.com/pesterhazy/presumably/blob/master/build.boot)
  - [nicerthantriton.com](https://nicerthantriton.com/). See [build.boot](https://github.com/bhagany/nicerthantriton.com/blob/master/build.boot)
+ - [200ok.ch](http://200ok.ch). See [build.boot](https://gitlab.com/200ok/200ok.gitlab.io/blob/master/build.boot)
 
 Also check out [examples](https://github.com/hashobject/perun/tree/master/examples) folder.
 


### PR DESCRIPTION
If you're interested in getting one more page on the list that looks a little different under the hood than the existing examples. Of course it's totally OK to reject the PR, because you already have a couple good examples of Perun pages. I won't be offended(;