### PR TITLE
Simplify markdown extension specification

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -369,12 +369,12 @@
   [d out-dir  OUTDIR str  "the output directory"
    _ filterer FILTER code "predicate to use for selecting entries (default: `identity`)"
    m meta     META   edn  "metadata to set on each entry; keys here will be overridden by metadata in each file"
-   o options  OPTS   edn  "options to be passed to the markdown parser"]
+   e md-exts  MDEXTS edn  "parsing extensions to be used by the markdown parser"]
   (let [pod (create-pod markdown-deps)
-        options* (merge +markdown-defaults+ *opts*)]
+        options (merge +markdown-defaults+ *opts*)]
     (content-pre-wrap
-     {:render-form-fn (fn [data] `(io.perun.markdown/process-markdown ~data ~options))
-      :paths-fn #(content-paths % (assoc options*
+     {:render-form-fn (fn [data] `(io.perun.markdown/process-markdown ~data ~md-exts))
+      :paths-fn #(content-paths % (assoc options
                                          :output-extension ".html"
                                          :extensions [".md" ".markdown"]))
       :passthru-fn content-passthru
@@ -394,10 +394,10 @@
   [d out-dir  OUTDIR str  "the output directory"
    _ filterer FILTER code "predicate to use for selecting entries (default: `identity`)"
    m meta     META   edn  "metadata to set on each entry; keys here will be overridden by metadata in each file"
-   o options  OPTS   edn  "options to be passed to the markdown parser"]
-  (let [{:keys [out-dir filterer meta options]} (merge +markdown-defaults+ *opts*)]
+   e md-exts  MDEXTS edn  "parsing extensions to be used by the markdown parser"]
+  (let [{:keys [out-dir filterer meta md-exts]} (merge +markdown-defaults+ *opts*)]
     (comp (yaml-metadata :filterer filterer :extensions [".md" ".markdown"])
-          (markdown* :out-dir out-dir :filterer filterer :meta meta :options options))))
+          (markdown* :out-dir out-dir :filterer filterer :meta meta :md-exts md-exts))))
 
 (deftask global-metadata
   "Read global metadata from `perun.base.edn` or configured file.

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -42,14 +42,14 @@
        (apply bit-or 0)
        int))
 
-(defn markdown-to-html [file-content options]
-  (let [processor (PegDownProcessor. (extensions-map->int (:extensions options)))]
+(defn markdown-to-html [file-content extensions]
+  (let [processor (PegDownProcessor. (extensions-map->int extensions))]
     (->> file-content
          char-array
          (.markdownToHtml processor))))
 
-(defn process-markdown [{:keys [entry]} options]
+(defn process-markdown [{:keys [entry]} extensions]
   (perun/report-debug "markdown" "processing markdown" (:filename entry))
   (let [file-content (-> entry :full-path io/file slurp)
-        html (markdown-to-html file-content options)]
+        html (markdown-to-html file-content extensions)]
     (assoc entry :rendered html)))

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -373,7 +373,7 @@ This --- be ___markdown___.")
         (p/markdown :out-dir "hammock"
                     :filterer #(= (:path %) "test.md")
                     :meta {:markdown-set :metadata}
-                    :options {:extensions {:smarts true}})
+                    :md-exts {:smarts true})
         (testing "markdown"
           (content-check :path "hammock/test.html"
                          :content parsed-md-smarts


### PR DESCRIPTION
Small backwards incompatibility here - the we only used the `:extensions` key of the `options` map passed to `markdown`.  This tripped me up when I first started learning Perun, because I didn't understand why we were wrapping the extensions map in another map (I assume something other than `:extensions` was used at some point in time).