### PR TITLE
Atom upgrades

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -82,6 +82,30 @@ All posts have a path which is used as a key to identify the post.
 - **:include-rss**
     - Set by: *markdown*, true by default
     - Used by: *rss*
+- **:tags**
+    - Used by: *tags*, *atom-feed*
+- **:tag**
+    - Set by: *tags*, on the pages generated for each tag listed
+- **:page**
+    - The number of this page
+    - Set by: *paginate*
+    - Set by: *atom-feed*
+- **:first-page**
+    - The filename of the first page in this group of pages
+    - Set by: *paginate*
+    - Set by: *atom-feed*
+- **:last-page**
+    - The filename of the last page in this group of pages
+    - Set by: *paginate*
+    - Set by: *atom-feed*
+- **:prev-page**
+    - The filename of the previous page in this group of pages, if it exists
+    - Set by: *paginate*
+    - Set by: *atom-feed*
+- **:next-page**
+    - The filename of the next page in this group of pages, if it exists
+    - Set by: *paginate*
+    - Set by: *atom-feed*
 - **:io.perun/trace**
     - Conjed onto by every task that modifies metadata
     - Serves as a record of tasks to touch a file

--- a/build.boot
+++ b/build.boot
@@ -16,10 +16,9 @@
                   [org.clojure/tools.namespace "0.3.0-alpha3" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
+(require '[io.perun.core :refer [+version+]])
 (require '[io.perun-test])
 (require '[boot.test :refer [runtests]])
-
-(def +version+ "0.4.2-SNAPSHOT")
 
 (bootlaces! +version+)
 
@@ -42,17 +41,6 @@
   []
   (comp (build-jar) (push-snapshot)))
 
-(deftask dev
-  "Dev process"
-  []
-  (comp
-    (watch)
-    (repl :server true)
-    (pom)
-    (jar)
-    (install)))
-
-
 (deftask build
   "Build process"
   []
@@ -60,3 +48,11 @@
     (pom)
     (jar)
     (install)))
+
+(deftask dev
+  "Dev process"
+  []
+  (comp
+    (watch)
+    (repl :server true)
+    (build)))

--- a/src/io/perun/atom.clj
+++ b/src/io/perun/atom.clj
@@ -29,7 +29,8 @@
        (into {})))
 
 (defn generate-atom [{:keys [entry entries meta]}]
-  (let [{:keys [site-title description base-url canonical-url] :as options} (merge meta entry)
+  (let [{:keys [site-title description base-url
+                canonical-url io.perun/version] :as options} (merge meta entry)
         {global-author :author global-author-email :author-email} meta
         navs (nav-hrefs options)
         atom (xml/emit-str
@@ -38,8 +39,7 @@
                 [:title site-title]
                 (when (seq description)
                   [:subtitle description])
-                ;; FIXME: :version property
-                [:generator {:uri "https://perun.io/"} "Perun"]
+                [:generator {:uri "https://perun.io/" :version version} "Perun"]
                 [:link {:href base-url :type "text/html"}]
                 [:link {:href canonical-url :rel "self"}]
                 [:link {:href (:first navs) :rel "first"}]

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -5,6 +5,8 @@
             [boot.from.io.aviso.ansi :as ansi]
             [boot.util               :as u]))
 
+(def +version+ "0.4.2-SNAPSHOT")
+
 (defn report-info [task msg & args]
   (apply u/info
         (str

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -70,3 +70,20 @@
   (assert (= \/ (last base-url))
           "base-url must end in \"/\"")
   base-url)
+
+(defn path->permalink
+  [path doc-root]
+  (let [match-doc-root (re-pattern (str "^" doc-root))]
+    (-> path
+        (string/replace match-doc-root "")
+        (string/replace #"(^|/)index\.html$" "/")
+        absolutize-url)))
+
+(defn permalink->canonical-url
+  [permalink base-url]
+  (str base-url (subs permalink 1)))
+
+(defn path->canonical-url
+  [path doc-root base-url]
+  (let [permalink (path->permalink path doc-root)]
+    (permalink->canonical-url permalink base-url)))

--- a/src/io/perun/meta.clj
+++ b/src/io/perun/meta.clj
@@ -10,7 +10,8 @@
 (def +global-meta-key+ :io.perun.global)
 
 (def +global-meta-defaults+
-  {:doc-root "public"})
+  {:doc-root "public"
+   :io.perun/version perun/+version+})
 
 (defn get-global-meta
   "Return global metadata that is related to the whole project

--- a/src/io/perun/meta.clj
+++ b/src/io/perun/meta.clj
@@ -29,11 +29,7 @@
   (let [file (or file (io/file path))
         filename (.getName file)
         slug (slug filename)
-        match-doc-root (re-pattern (str "^" doc-root))
-        permalink (-> path
-                      (string/replace match-doc-root "")
-                      (string/replace #"(^|/)index\.html$" "/")
-                      perun/absolutize-url)]
+        permalink (perun/path->permalink path doc-root)]
     (merge {:path path
             :parent-path (perun/parent-path path filename)
             :full-path (.getPath file)
@@ -44,7 +40,8 @@
             :extension (perun/extension filename)}
            (when base-url
              (perun/assert-base-url base-url)
-             {:canonical-url (str base-url (subs permalink 1))}))))
+             {:canonical-url (perun/permalink->canonical-url
+                              permalink base-url)}))))
 
 (defn meta-from-file
   [fileset tmpfile]

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -560,7 +560,7 @@ This --- be ___markdown___.")
 
         (p/paginate :renderer 'io.perun-test/render-paginate
                     :out-dir "baz"
-                    :prefix "decomplect-"
+                    :filename-fn #(str "decomplect-" % ".html")
                     :page-size 2
                     :filterer :assorting
                     :extensions [".htm"]


### PR DESCRIPTION
My primary motivation was to get paginated Atom feeds, so that more than 10 items can be retrieved by clients, but also feed pages don't get too large. Along the way, I also addressed some of the FIXME's in atom.clj, upgraded the error reporting, and made good use of `content-pre-wrap`.

Enabling pagination for `atom-feed` entailed upgrading `paginate` as well - it now adds more useful metadata to the generated pages.  I've updated the spec document accordingly.

There is one backwards incompatible change for `paginate`.  Where it previously took a `prefix` option, it now takes a `filename-fn`.  This can be made to do the same thing `prefix` did, but also allows you to come up with page naming schemes that don't fall within the narrow confines of page-1, page-2, etc.