### PR TITLE
Lucene word count

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -445,7 +445,7 @@
         (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-metas))
         (pm/set-meta fileset updated-metas)))))
 
-(def ^:private word-count-deps
+(def ^:private ^:deps word-count-deps
   '[[org.clojure/tools.namespace "0.3.0-alpha3"]
     [org.apache.lucene/lucene-analyzers-common "6.4.1"]])
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -458,7 +458,7 @@
    e extensions EXTENSIONS [str] "extensions of files to include"]
   (let [pod     (create-pod word-count-deps)
         options (merge +word-count-defaults+ *opts*)]
-    (content-pre-wrap
+    (content-task
      {:render-form-fn (fn [data] `(io.perun.word-count/word-count ~data))
       :paths-fn #(content-paths % options)
       :passthru-fn content-passthru

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -442,6 +442,10 @@
         (perun/report-debug "ttr" "generated time-to-read" (map :ttr updated-metas))
         (pm/set-meta fileset updated-metas)))))
 
+(def ^:private word-count-deps
+  '[[org.clojure/tools.namespace "0.3.0-alpha3"]
+    [org.apache.lucene/lucene-analyzers-common "6.4.1"]])
+
 (def ^:private +word-count-defaults+
   {:filterer identity
    :extensions [".html"]})
@@ -450,16 +454,15 @@
   "Count words in each file. Add `:word-count` key to the files' meta"
   [_ filterer   FILTER     code  "predicate to use for selecting entries (default: `identity`)"
    e extensions EXTENSIONS [str] "extensions of files to include"]
-  (let [options (merge +word-count-defaults+ *opts*)]
-    (boot/with-pre-wrap fileset
-      (let [updated-metas (->> (filter-tmp-by-ext fileset options)
-                               (keep #(when-let [content (-> % boot/tmp-file slurp)]
-                                        (let [meta (pm/meta-from-file fileset %)]
-                                          (assoc meta :word-count (count (string/split content #"\s"))))))
-                               (trace :io.perun/word-count))]
-        (perun/report-info "word-count" "added word-count to %s files" (count updated-metas))
-        (perun/report-debug "word-count" "counted words" (map :word-count updated-metas))
-        (pm/set-meta fileset updated-metas)))))
+  (let [pod     (create-pod word-count-deps)
+        options (merge +word-count-defaults+ *opts*)]
+    (content-pre-wrap
+     {:render-form-fn (fn [data] `(io.perun.word-count/word-count ~data))
+      :paths-fn #(content-paths % options)
+      :passthru-fn content-passthru
+      :task-name "word-count"
+      :tracer :io.perun/word-count
+      :pod pod})))
 
 (def ^:private gravatar-deps
   '[[gravatar "1.1.1"]])

--- a/src/io/perun/word_count.clj
+++ b/src/io/perun/word_count.clj
@@ -1,0 +1,19 @@
+(ns io.perun.word-count
+  (:require [clojure.java.io :as io])
+  (:import [org.apache.lucene.analysis.charfilter HTMLStripCharFilter]
+           [org.apache.lucene.analysis.standard StandardTokenizer]
+           [org.apache.lucene.analysis.tokenattributes CharTermAttribute]))
+
+(defn word-count [{:keys [entry]}]
+  (let [tokenizer (StandardTokenizer.)
+        char-attr (.getAttribute tokenizer CharTermAttribute)
+        content (slurp (io/file (:full-path entry)))
+        html-filter (HTMLStripCharFilter. (java.io.StringReader. content))]
+    (.setReader ^StandardTokenizer tokenizer html-filter)
+    (.reset tokenizer)
+    (let [ct (loop [c 0]
+               (if-not (.incrementToken tokenizer)
+                 c
+                 (recur (inc c))))]
+      (.close tokenizer)
+      (assoc entry :word-count ct))))

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -247,7 +247,7 @@ This --- be ___markdown___.")
         (p/word-count)
         (testing "word-count"
           (value-check :path "public/2017-01-01-test.html"
-                       :value-fn #(meta= %1 %2 :word-count 8)
+                       :value-fn #(meta= %1 %2 :word-count 5)
                        :msg "`word-count` should set `:word-count` metadata"))
 
         (p/gravatar :source-key :email :target-key :gravatar)
@@ -391,7 +391,7 @@ This --- be ___markdown___.")
                       :extensions [".htm"])
         (testing "word-count"
           (value-check :path "hammock/test.htm"
-                       :value-fn #(meta= %1 %2 :word-count 8)
+                       :value-fn #(meta= %1 %2 :word-count 5)
                        :msg "`word-count` should set `:word-count` metadata"))
 
         (p/gravatar :source-key :email


### PR DESCRIPTION
Previously, word counting just split on whitespace and counted the parts, but this doesn't really count words for the common use-cases in Perun.  For instance, if you run `word-count` on this markdown:

```markdown
# Hello there

This --- be ___markdown___.
```

it counts 8 words, but it's really 5.  It's worse if you run `word-count` on HTML, because it would count things that are inside tags like `<a href="/" class="some-class">`.

This PR fixes all that by using Lucene's standard tokenizer, which should work for most languages.  It won't work that great for Chinese, Japanese, or Thai, but splitting on whitespace won't work for those languages either, and I believe support can be added to this implementation later if there's a demand.