### PR TITLE
Add pandoc task

### DIFF
--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Oracle Java 8
 
 RUN apt-get update \
-    && apt-get install -y curl wget openssl ca-certificates \
+    && apt-get install -y curl wget openssl ca-certificates pandoc\
     && cd /tmp \
     && wget -qO jdk8.tar.gz \
        --header "Cookie: oraclelicense=accept-securebackup-cookie" \

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -426,7 +426,7 @@
    m meta       META       edn   "metadata to set on each entry"
    o cmd-opts   CMDOPTS    [str] "command line options to send to pandoc"]
   (let [options (merge +pandoc-defaults+ *opts*)]
-    (content-pre-wrap
+    (content-task
      {:render-form-fn (fn [data] `(io.perun.pandoc/process-pandoc ~data ~cmd-opts))
       :paths-fn #(content-paths % options)
       :passthru-fn content-passthru

--- a/src/io/perun/pandoc.clj
+++ b/src/io/perun/pandoc.clj
@@ -1,0 +1,12 @@
+(ns io.perun.pandoc
+  (:require [io.perun.core :as perun]
+            [boot.from.me.raynes.conch :as conch]))
+
+(defn process-pandoc [{:keys [entry]} cmd-opts]
+  (perun/report-debug "pandoc" "processing pandoc" (:path entry))
+  (let [p (apply conch/proc "pandoc" (conj cmd-opts (:full-path entry)))
+        html (conch/stream-to-string p :out)]
+    (conch/destroy p)
+    (when (not= (conch/exit-code p) 0)
+      (perun/report-info "pandoc" "error in pandoc process for %s" (:path entry)))
+    (assoc entry :rendered html)))

--- a/src/io/perun/yaml.clj
+++ b/src/io/perun/yaml.clj
@@ -42,9 +42,12 @@
       (first (drop 2 splitted))
       content)))
 
-(defn parse-yaml [{:keys [entry]}]
+(defn parse-yaml [{:keys [entry]} keep-yaml]
   (let [content (-> entry :full-path io/file slurp)
         parsed-metadata (if-let [metadata-str (substr-between content *yaml-head* *yaml-head*)]
                           (normal-colls (yaml/parse-string metadata-str))
-                          {})]
-    (merge entry parsed-metadata {:rendered (remove-metadata content)})))
+                          {})
+        rendered (if keep-yaml
+                   content
+                   (remove-metadata content))]
+    (merge entry parsed-metadata {:rendered rendered})))


### PR DESCRIPTION
Seeking feedback on this - Pandoc has been discussed before (notably in #48), with a few different approaches presented.  The current state of this PR is "the simplest thing possible" - the `pandoc` task takes a vector of command line arguments to pass on to the `pandoc` binary.  I'm not sure this is the best way, and I'd like to hear what the community thinks.