### PR TITLE
Always produce relative paths using `create-filepath`

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -637,6 +637,7 @@
         path-fn (fn [global-meta m]
                   (let [permalink (permalink-fn global-meta m)]
                     (str (:doc-root global-meta)
+                         "/"
                          (perun/url-to-path (string/replace permalink #"/$" "/index.html")))))]
     (mv-pre-wrap {:task-name "permalink"
                   :path-fn path-fn

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -49,7 +49,7 @@
 (defn create-filepath
   "Creates a filepath using system path separator."
   [& args]
-  (.getPath (apply io/file args)))
+  (.getPath (apply io/file (remove empty? args))))
 
 (defn url-to-path
   "Converts a url to filepath."


### PR DESCRIPTION
Fix bug with passing an empty string as `:out-dir`, reported on Slack by @martinklepsch 