### PR TITLE
Fix #175 - merge `atom-feed` task options

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -1086,8 +1086,15 @@
                         1 filename
                         (str (perun/filename filename) "-" i
                              "." (perun/extension filename))))
-        options (assoc options*
-                       :grouper (page-grouper-fn (assoc options* :filename-fn filename-fn)))]
+        page-fn (page-grouper-fn (assoc options* :filename-fn filename-fn))
+        global-overrides (select-keys options* [:site-title :description :base-url])
+        meta-grouper (fn [entries]
+                       (->> entries
+                            page-fn
+                            (map (fn [[path data]]
+                                   [path (update-in data [:entry] merge global-overrides)]))
+                            (into {})))
+        options (assoc options* :grouper meta-grouper)]
     (content-task
      {:render-form-fn (fn [data] `(io.perun.atom/generate-atom ~data))
       :paths-fn #(atom-paths % options)

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -501,8 +501,15 @@ This --- be ___markdown___.")
                      :site-title "Test Site"
                      :description "Here we go a-testing")
         (testing "atom-feed"
-          (file-exists? :path (perun/url-to-path "foo/test-atom.xml")
-                        :msg "`atom-feed` should write test-atom.xml"))
+          (comp
+           (file-exists? :path (perun/url-to-path "foo/test-atom.xml")
+                         :msg "`atom-feed` should write test-atom.xml")
+           (content-check :path (perun/url-to-path "foo/test-atom.xml")
+                          :content "http://bar.com/")
+           (content-check :path (perun/url-to-path "foo/test-atom.xml")
+                          :content "Test Site")
+           (content-check :path (perun/url-to-path "foo/test-atom.xml")
+                          :content "Here we go a-testing")))
 
         (add-txt-file :path "test1.md" :content (nth input-strings 2))
         (add-txt-file :path "test2.md" :content (nth input-strings 3))


### PR DESCRIPTION
Task arguments that should override global metadata were not being
passed to the atom rendering function. Added tests to cover this
case.