### PR TITLE
Avoid re-rendering the same content in `yaml-metadata`

### DIFF
--- a/src/io/perun/yaml.clj
+++ b/src/io/perun/yaml.clj
@@ -47,7 +47,7 @@
         parsed-metadata (if-let [metadata-str (substr-between content *yaml-head* *yaml-head*)]
                           (normal-colls (yaml/parse-string metadata-str))
                           {})
-        rendered (if keep-yaml
-                   content
-                   (remove-metadata content))]
-    (merge entry parsed-metadata {:rendered rendered})))
+        metadata (merge entry parsed-metadata)]
+    (if keep-yaml
+      metadata
+      (assoc metadata :rendered (remove-metadata content)))))


### PR DESCRIPTION
This is not a big deal, just a small efficiency tweak.  It has been in the back of my mind since I realized it, and I'd just like to stop thinking about it.