### PR TITLE
`yaml-metadata` should not remove originals, to accomodate `keep-yaml :true`

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -350,7 +350,6 @@
       :passthru-fn content-passthru
       :task-name "yaml-metadata"
       :tracer :io.perun/yaml-metadata
-      :rm-originals true
       :pod pod})))
 
 (def ^:private ^:deps markdown-deps


### PR DESCRIPTION
I don't think the previous render-yaml branch actually passed tests... this one does.