### PR TITLE
Implement #181 - web app manifest support

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -1330,7 +1330,7 @@
 (deftask manifest
   "Creates a manifest.json for installable web applications"
   [o out-dir          OUTDIR      str    "the output directory"
-   i icon-path        PATH        str    "The input icon to be resized (default \"icon.png\""
+   i icon-path        PATH        str    "The input icon to be resized (default \"icon.png\")"
    r resolutions      RESOLUTIONS #{int} "resolutions to which images should be resized (default #{192 512})"
    t site-title       TITLE       str    "name for the installable web application"
    l short-title      SHORTTITLE  str    "short name for the installable web application (default :site-title)"

--- a/src/io/perun/manifest.clj
+++ b/src/io/perun/manifest.clj
@@ -1,0 +1,15 @@
+(ns io.perun.manifest
+  (:require [cheshire.core :refer [generate-string]]))
+
+(defn manifest
+  [{:keys [icons site-title theme-color display scope input-paths] :as data}]
+  (let [manifest {:name site-title
+                  :icons (for [{:keys [permalink width height mime-type]} icons]
+                           {:src permalink
+                            :sizes (str width "x" height)
+                            :type mime-type})
+                  :theme_color theme-color
+                  :display display
+                  :scope scope}]
+    {:rendered (generate-string manifest)
+     :input-paths input-paths}))

--- a/src/io/perun/manifest.clj
+++ b/src/io/perun/manifest.clj
@@ -2,13 +2,15 @@
   (:require [cheshire.core :refer [generate-string]]))
 
 (defn manifest
-  [{:keys [icons site-title theme-color display scope input-paths] :as data}]
+  [{:keys [icons site-title short-title theme-color background-color display scope input-paths] :as data}]
   (let [manifest {:name site-title
+                  :short_name short-title
                   :icons (for [{:keys [permalink width height mime-type]} icons]
                            {:src permalink
                             :sizes (str width "x" height)
                             :type mime-type})
                   :theme_color theme-color
+                  :background_color background-color
                   :display display
                   :scope scope}]
     {:rendered (generate-string manifest)

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -444,7 +444,17 @@ This --- be _asciidoc_.")
         (testing "draft"
           (file-exists? :path (perun/url-to-path "public/test/index.html")
                         :negate? true
-                        :msg "`draft` should remove files"))))
+                        :msg "`draft` should remove files"))
+
+        (add-image :path "icon.png" :type "PNG" :width 10 :height 10)
+        (p/manifest)
+        (testing "manifest"
+          (file-exists? :path (perun/url-to-path "public/manifest.json")
+                        :msg "`manifest` should write manifest.json")
+          (file-exists? :path (perun/url-to-path "public/icon_192.png")
+                        :msg "`manifest` should write icon resized to 192px")
+          (file-exists? :path (perun/url-to-path "public/icon_512.png")
+                        :msg "`manifest` should write icon resized to 512px"))))
 
 (deftesttask with-arguments-test []
   (comp (boot/with-pre-wrap fileset
@@ -757,7 +767,21 @@ This --- be _asciidoc_.")
            (content-check :path "baz.htm"
                           :content (str "<script>" js-content "</script>")
                           :negate? true
-                          :msg "`inject-scripts` should not alter the contents of a removed file")))))
+                          :msg "`inject-scripts` should not alter the contents of a removed file")))
+
+        (add-image :path "an-icon.png" :type "PNG" :width 10 :height 10)
+        (p/manifest :out-dir "foop"
+                    :icon-path "an-icon.png"
+                    :resolutions #{20}
+                    :site-title "Blarg"
+                    :theme-color "#f0987d"
+                    :display "fullscreen"
+                    :scope "/blarp")
+        (testing "manifest"
+          (file-exists? :path (perun/url-to-path "foop/manifest.json")
+                        :msg "`manifest` should write manifest.json")
+          (file-exists? :path (perun/url-to-path "foop/an-icon_20.png")
+                        :msg "`manifest` should write icon resized to 20px"))))
 
 (deftesttask content-tests []
   (comp (testing "Collection works without input files" ;; #77


### PR DESCRIPTION
This feature will allow sites built with Perun to be installed as an app on systems that support it. When paired with #180, this will be a slick offline experience.

This was a bit more work to implement properly than I thought at first, primarily because I wanted to support automatically handling image files for the icons that are referenced in manifest.json.  This required a refactor for `images-resize`, which is backwards-compatible.  This in turn caused another small backwards-compatible addition to `content-task` to allow a boot tmp directory to be passed.  This was necessary to accommodate tasks that want to write directly to tmp directories from within their pod, rather than passing data back to the main pod, as is the case for the image-handling tasks.

Other changes here are small improvements like pruning unused requires, and consistently handling the `out-dir` parameter to tasks.  These should be self-explanatory, but if you have questions let me know.

I've also added tests for `manifest`.