### PR TITLE
fix: asciidoc yaml parsing

### DIFF
--- a/src/io/perun/yaml.clj
+++ b/src/io/perun/yaml.clj
@@ -7,7 +7,7 @@
   (:import [flatland.ordered.map OrderedMap]
            [flatland.ordered.set OrderedSet]))
 
-(def ^:dynamic *yaml-head* #"---\r?\n")
+(def ^:dynamic *yaml-head* #"(?<=^|\n)---\r?\n")
 
 (defn substr-between
   "Find string that is nested in between two strings. Return first match.


### PR DESCRIPTION
Fixes the issue as described in https://github.com/hashobject/perun/issues/192
by checking the triple dash to be prefixed by either the start of the document,
or the start of a new line. This does still allow for some content before the
actual yaml.