### PR TITLE
feat: asciidoctor-diagram support

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -459,7 +459,8 @@
                    :cmd-opts cmd-opts))))
 
 (def ^:private ^:deps asciidoctor-deps
-  '[[org.clojure/tools.namespace "0.3.0-alpha3"]
+  '[[clj-time "0.14.0"]
+    [org.clojure/tools.namespace "0.3.0-alpha3"]
     [org.asciidoctor/asciidoctorj "1.5.4"]])
 
 (def ^:private +asciidoctor-defaults+

--- a/src/io/perun/asciidoctor.clj
+++ b/src/io/perun/asciidoctor.clj
@@ -1,16 +1,79 @@
 (ns io.perun.asciidoctor
   (:require [io.perun.core :as perun]
+            [clj-time.coerce :as tc]
+            [clj-time.format :as tf]
             [clojure.java.io :as io])
   (:import [org.asciidoctor Asciidoctor Asciidoctor$Factory]))
+
+(defn keywords->names
+  "Converts a map with keywords to a map with named keys. Only handles the top
+   level of any nested structure."
+  [m]
+  (reduce-kv #(assoc %1 (name %2) %3) {} m))
+
+(defn names->keywords
+  "Converts a map with named keys to a map with keywords. Only handles the top
+   level of any nested structure."
+  [m]
+  (reduce-kv #(assoc %1 (keyword %2) %3) {} m))
 
 (def container
   (Asciidoctor$Factory/create ""))
 
-(defn asciidoctor-to-html [file-content]
-  (.convert container file-content {}))
+(defn meta->attributes
+  "Takes the Perun meta and converts it to a collection of attributes, which can
+  be handed to the AsciidoctorJ process."
+  [meta]
+  (-> meta
+      keywords->names
+      (java.util.HashMap.)))
+
+(defn parse-date
+  "Tries to parse a date string into a DateTime object"
+  [date]
+  (when date
+    (if-let [parsed (tc/to-date date)]
+      parsed
+      (perun/report-info "asciidoctor" "failed to parse date %s" date))))
+
+(defn attributes->meta
+  "Add duplicate entries for the metadata keys gathered from the AsciidoctorJ
+  parsing using keys that adhere to the Perun specification of keys. The native
+  AsciidoctorJ keys are still available."
+  [attributes]
+  (let [meta (names->keywords (into {} attributes))]
+    (merge meta
+           {:author-email   (:email     meta)
+            :title          (:doctitle  meta)
+            :date-published (parse-date (:revdate meta))})))
+
+(defn protect-meta
+  "Strip keywords from metadata that are being used by Perun to properly
+  function."
+  [meta]
+  (dissoc meta
+          :canonical-url :extension :filename :full-path :parent-path :permalink
+          :short-filename :slug))
+
+(defn parse-file-metadata
+  "Processes the asciidoctor content and extracts all the attributes."
+  [adoc-content]
+  (->> (.readDocumentStructure container adoc-content {})
+       (.getHeader)
+       (.getAttributes)
+       attributes->meta
+       protect-meta))
+
+(defn asciidoctor-to-html [file-content attributes]
+  (let [options (if attributes
+                  {"attributes" attributes}
+                  {})]
+    (.convert container file-content options)))
 
 (defn process-asciidoctor [{:keys [entry]}]
   (perun/report-debug "asciidoctor" "processing asciidoctor" (:filename entry))
   (let [file-content (-> entry :full-path io/file slurp)
-        html         (asciidoctor-to-html file-content)]
-    (assoc entry :rendered html)))
+        attributes   (meta->attributes entry)
+        html         (asciidoctor-to-html file-content attributes)
+        meta         (parse-file-metadata file-content)]
+    (merge (assoc entry :rendered html) meta)))

--- a/src/io/perun/yaml.clj
+++ b/src/io/perun/yaml.clj
@@ -7,7 +7,7 @@
   (:import [flatland.ordered.map OrderedMap]
            [flatland.ordered.set OrderedSet]))
 
-(def ^:dynamic *yaml-head* #"---\r?\n")
+(def ^:dynamic *yaml-head* #"(?<=^|\n)---\r?\n")
 
 (defn substr-between
   "Find string that is nested in between two strings. Return first match.


### PR DESCRIPTION
Enables `asciidoctor-diagram` support for generating images as defined inline in the source file. The resulting images are captured afterwards in a new task named `collect-images`, to stick to the basic content-task structure for the base asciidoctor task.

Previous code was refactored to have stronger defaults for options and metadata handling.

Based on the previous PR's https://github.com/hashobject/perun/pull/191 and https://github.com/hashobject/perun/pull/193

I'm very interested to hear your comments on this work:
- Is the `collect-images` task the right way to collect images after the `content-task` function?
- The `asciidoctor*` now has a global switch on `diagram` to determine whether or not `asciidoctor-diagram` is enabled. Is this correct?
- Is there a way I can move both the images and the post with the `permalink` task so the relative URL remains the same? Another way would be to fix this upfront, by giving each post it's own directory or by changing the relative URL named `imagesdir` in asciidoctor terminology.

At the moment of writing you can observe the potential output at http://site.nicorikken.eu/posts/2017-08-14-testpost.html which is based on the source https://github.com/nicorikken/nicorikken.github.io/tree/perun which uses the code of this PR.