### PR TITLE
Highlight task

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -507,6 +507,33 @@
                         :extensions extensions
                         :meta       meta))))
 
+(def ^:private ^:deps highlight-deps
+  '[[org.clojure/tools.namespace "0.3.0-alpha3"]
+    [enlive "1.1.5"]
+    [clygments "1.0.0"]])
+
+(def ^:private +highlight-defaults+
+  {:filterer identity
+   :class "highlight"
+   :extensions [".html"]})
+
+(deftask highlight
+  "Syntax highlighting for code blocks using Pygments.
+
+   Requires Pygments CSS styles to be present, see https://github.com/richleland/pygments-css."
+  [_ filterer FILTER code "predicate to use for selecting entries (default: `identity`)"
+   _ class    CLASS  str  "CSS class to wrap code blocks with (default: `highlight`)"]
+  (let [pod     (create-pod highlight-deps)
+        options (merge +highlight-defaults+ *opts*)]
+    (content-task
+     {:render-form-fn (fn [data] `(io.perun.highlight/highlight-code-blocks ~data ~(:class options)))
+      :paths-fn #(content-paths % options)
+      :passthru-fn content-passthru
+      :task-name "highlight"
+      :tracer :io.perun/highlight
+      :rm-originals true
+      :pod pod})))
+
 (deftask global-metadata
   "Read global metadata from `perun.base.edn` or configured file.
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -520,9 +520,10 @@
 (deftask highlight
   "Syntax highlighting for code blocks using Pygments.
 
-   Requires Pygments CSS styles to be present, see https://github.com/richleland/pygments-css."
-  [_ filterer FILTER code "predicate to use for selecting entries (default: `identity`)"
-   _ class    CLASS  str  "CSS class to wrap code blocks with (default: `highlight`)"]
+   Pygments CSS styles must be provided, see https://github.com/richleland/pygments-css."
+  [_ filterer   FILTER     code  "predicate to use for selecting entries (default: `identity`)"
+   e extensions EXTENSIONS [str] "extensions of files to process"
+   c class      CLASS      str   "CSS class to wrap code blocks with (default: `highlight`)"]
   (let [pod     (create-pod highlight-deps)
         options (merge +highlight-defaults+ *opts*)]
     (content-task

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -5,7 +5,7 @@
             [boot.from.io.aviso.ansi :as ansi]
             [boot.util               :as u]))
 
-(def +version+ "0.4.2-SNAPSHOT")
+(def +version+ "0.4.3-SNAPSHOT")
 
 (defn report-info [task msg & args]
   (apply u/info

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -5,7 +5,7 @@
             [boot.from.io.aviso.ansi :as ansi]
             [boot.util               :as u]))
 
-(def +version+ "0.4.3-SNAPSHOT")
+(def +version+ "0.4.2-SNAPSHOT")
 
 (defn report-info [task msg & args]
   (apply u/info

--- a/src/io/perun/highlight.clj
+++ b/src/io/perun/highlight.clj
@@ -1,0 +1,30 @@
+(ns io.perun.highlight
+  (:require [clojure.java.io :as io]
+            [clygments.core :as pygments]
+            [net.cgrand.enlive-html :as enlive]))
+
+;; adapted from
+;; http://cjohansen.no/building-static-sites-in-clojure-with-stasis/
+
+(defn- extract-code
+  [highlighted]
+  (-> highlighted
+      java.io.StringReader.
+      enlive/html-resource
+      (enlive/select [:pre])
+      first
+      :content))
+
+(defn- highlight [node]
+  (let [code (->> node :content (apply str))
+        lang (-> node :attrs :class (clojure.string/replace #"language-" "") keyword)]
+    (assoc node :content (-> code
+                             (pygments/highlight lang :html)
+                             extract-code))))
+
+(defn highlight-code-blocks [{:keys [entry]} cls]
+  (let [content (-> entry :full-path io/file slurp)]
+    (assoc entry :rendered (enlive/sniptest
+                            content
+                            [:pre [:code (enlive/attr? :class)]] highlight
+                            [:pre [:code (enlive/attr? :class)]] #(assoc-in % [:attrs :class] cls)))))

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -193,9 +193,20 @@ This --- be ___markdown___.")
 
 This --- be _asciidoc_.")
 
-(def input-strings (map #(str "---\n" % "\n---\n" md-content) yamls))
+(defn meta-block
+  [meta]
+  (str "---\n" meta "\n---\n"))
 
-(def adoc-input-strings (map #(str "---\n" % "\n---\n" adoc-content) yamls))
+(def input-strings (map #(str (meta-block %) md-content) yamls))
+
+(def adoc-input-strings (map #(str (meta-block %) adoc-content) yamls))
+
+(def highlight-input-string
+  (str
+   (meta-block (yaml/generate-string (assoc base-meta :uuid "f948c938-3cf2-4feb-bf02-f284c2fe9665")))
+   "```scss
+@import 'bootstrap';
+```"))
 
 (def parsed-md-basic "<h1><a href=\"#hello-there\" id=\"hello-there\"></a>Hello there</h1>\n<p>This --- be <strong><em>markdown</em></strong>.</p>\n")
 
@@ -206,6 +217,8 @@ This --- be _asciidoc_.")
 (def parsed-asciidoctor-adoc "<div class=\"paragraph\">\n<p>This --- be <em>asciidoc</em>.</p>\n</div>")
 
 (def parsed-md-smarts "<h1><a href=\"#hello-there\" id=\"hello-there\"></a>Hello there</h1>\n<p>This &mdash; be <strong><em>markdown</em></strong>.</p>\n")
+
+(def highlighted-md "<pre><code class=\"highlight\"><span></span><span class=\"k\">@import</span> <span class=\"s1\">'</span><span class=\"s2\">bootstrap'</span><span class=\"p\">;</span>\n</code></pre>")
 
 (def js-content "(function somejs() { console.log('$foo'); })();")
 
@@ -278,6 +291,15 @@ This --- be _asciidoc_.")
           (content-check :path (perun/url-to-path "public/2017-01-01-test.html")
                          :content parsed-md-basic
                          :msg "`markdown` should populate HTML file with parsed content"))
+
+        (add-txt-file :path "highlight-test.md" :content highlight-input-string)
+        (p/markdown)
+        (p/highlight)
+
+        (testing "highlight"
+          (content-check :path (perun/url-to-path "public/highlight-test.html")
+                         :content highlighted-md
+                         :msg "`highlight` should add Pygments syntax highlighting to HTML file"))
 
         (p/ttr)
         (testing "ttr"
@@ -352,13 +374,13 @@ This --- be _asciidoc_.")
         (p/assortment :renderer 'io.perun-test/render-assortment)
         (testing "assortment"
           (content-check :path (perun/url-to-path "public/index.html")
-                         :content "assortment 5"
+                         :content "assortment 6"
                          :msg "assortment should modify file contents"))
 
         (p/collection :renderer 'io.perun-test/render-collection)
         (testing "collection"
           (content-check :path (perun/url-to-path "public/index.html")
-                         :content "collection 6"
+                         :content "collection 7"
                          :msg "collection should modify file contents"))
 
         (p/tags :renderer 'io.perun-test/render-tags)
@@ -377,7 +399,7 @@ This --- be _asciidoc_.")
         (p/paginate :renderer 'io.perun-test/render-paginate)
         (testing "paginate"
           (content-check :path (perun/url-to-path "public/page-1.html")
-                         :content "paginate 9"
+                         :content "paginate 10"
                          :msg "`paginate` should write new files"))
 
         (p/static :renderer 'io.perun-test/render-static)

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -201,12 +201,20 @@ This --- be _asciidoc_.")
 
 (def adoc-input-strings (map #(str (meta-block %) adoc-content) yamls))
 
-(def highlight-input-string
+(def highlight-input-md-string
   (str
    (meta-block (yaml/generate-string (assoc base-meta :uuid "f948c938-3cf2-4feb-bf02-f284c2fe9665")))
    "```scss
 @import 'bootstrap';
 ```"))
+
+(def highlight-input-ad-string
+  (str
+   (meta-block (yaml/generate-string (assoc base-meta :uuid "ce14e4fc-8c65-4e26-94fe-55faaa650c01")))
+   "[source,scss]
+----
+@import 'bootstrap';
+----"))
 
 (def parsed-md-basic "<h1><a href=\"#hello-there\" id=\"hello-there\"></a>Hello there</h1>\n<p>This --- be <strong><em>markdown</em></strong>.</p>\n")
 
@@ -219,6 +227,8 @@ This --- be _asciidoc_.")
 (def parsed-md-smarts "<h1><a href=\"#hello-there\" id=\"hello-there\"></a>Hello there</h1>\n<p>This &mdash; be <strong><em>markdown</em></strong>.</p>\n")
 
 (def highlighted-md "<pre><code class=\"highlight\"><span></span><span class=\"k\">@import</span> <span class=\"s1\">'</span><span class=\"s2\">bootstrap'</span><span class=\"p\">;</span>\n</code></pre>")
+
+(def highlighted-ad "<pre class=\"highlight\"><code class=\"highlight\" data-lang=\"scss\"><span></span><span class=\"k\">@import</span> <span class=\"s1\">'</span><span class=\"s2\">bootstrap'</span><span class=\"p\">;</span>\n</code></pre>")
 
 (def js-content "(function somejs() { console.log('$foo'); })();")
 
@@ -292,13 +302,22 @@ This --- be _asciidoc_.")
                          :content parsed-md-basic
                          :msg "`markdown` should populate HTML file with parsed content"))
 
-        (add-txt-file :path "highlight-test.md" :content highlight-input-string)
+        (add-txt-file :path "highlight-test.md" :content highlight-input-md-string)
         (p/markdown)
         (p/highlight)
 
-        (testing "highlight"
+        (testing "highlight for markdown"
           (content-check :path (perun/url-to-path "public/highlight-test.html")
                          :content highlighted-md
+                         :msg "`highlight` should add Pygments syntax highlighting to HTML file"))
+
+        (add-txt-file :path "highlight-test.ad" :content highlight-input-ad-string)
+        (p/asciidoctor)
+        (p/highlight)
+
+        (testing "highlight for asciidoc"
+          (content-check :path (perun/url-to-path "public/highlight-test.html")
+                         :content highlighted-ad
                          :msg "`highlight` should add Pygments syntax highlighting to HTML file"))
 
         (p/ttr)


### PR DESCRIPTION
Add syntax highlighting task (fixes #32). Highlighting is done using Pygments and the [clygments](https://github.com/bfontaine/clygments) wrapper. I adapted a set of [guidelines for adding syntax highlighting to Stasis sites](http://cjohansen.no/building-static-sites-in-clojure-with-stasis/) for this.

Works by modifying HTML output. There are tests for markdown- and asciidoc-produced HTML.

If this gets merged, I'll make a PR to https://github.com/hashobject/perun.io as well to update the documentation of the built-in tasks.