### PR TITLE
[Fix #199] Rebuild file path from scratch with out-dir

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -805,11 +805,11 @@
     (letfn [(render-paths [fileset]
               (let [entries (filter-meta-by-ext fileset options)]
                 (reduce
-                 (fn [result {:keys [path out-dir] :as entry}]
+                 (fn [result {:keys [out-dir filename path] :as entry}]
                    (let [content (slurp (boot/tmp-file (boot/tmp-get fileset path)))
-                         path-args (if (= out-dir (:out-dir options))
+                         path-args (if (= out-dir (:out-dir options)) ;; if custom out-dir we cannot rely on pre-built :path
                                      [path]
-                                     [(:out-dir options) path])
+                                     [out-dir (:out-dir options) filename])
                          new-path (apply perun/create-filepath path-args)
                          new-entry (merge entry
                                           meta


### PR DESCRIPTION
The fix makes sure that the path in render is calculated from the right
individual pieces if out-dir is specified (and therefore not matching
:doc-root). The permalinks are now correctly generated.