### PR TITLE
Protect in case of missing <pre> in highlight

### DIFF
--- a/src/io/perun/highlight.clj
+++ b/src/io/perun/highlight.clj
@@ -8,12 +8,12 @@
 
 (defn- extract-code
   [highlighted]
-  (-> highlighted
-      java.io.StringReader.
-      enlive/html-resource
-      (enlive/select [:pre])
-      first
-      :content))
+  (some-> highlighted
+          java.io.StringReader.
+          enlive/html-resource
+          (enlive/select [:pre])
+          first
+          :content))
 
 (defn- highlight [node]
   (let [code (->> node :content (apply str))


### PR DESCRIPTION
The patch adds a some-> so that we avoid NullPointerExceptions if <pre> tags
are missing in the posts.