### PR TITLE
Use lessc dependencies to trigger re-renders

### DIFF
--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -1293,6 +1293,22 @@
    :extensions [".less"]
    :include-dirs []})
 
+(defn lessc-paths
+  [fileset options include-dirs-str pod]
+  (let [path-map (->> fileset
+                      pm/get-meta
+                      (map (juxt :full-path :path))
+                      (into {}))]
+    (reduce (fn [inputs [path {:keys [entry] :as input}]]
+              (pod/with-eval-in @pod (require 'io.perun.lessc))
+              (->> (pod/with-call-in @pod (io.perun.lessc/lessc-deps ~entry ~include-dirs-str))
+                   (map #(get path-map %))
+                   (filter identity)
+                   (update-in input [:input-paths] into)
+                   (assoc inputs path)))
+            {}
+            (content-paths fileset options))))
+
 (deftask lessc
   "Compile CSS using Less.
 
@@ -1306,14 +1322,17 @@
   (let [options (merge +lessc-defaults+ *opts*)
         include-dirs-str (->> (:include-dirs options)
                               (mapcat (fn [dir]
-                                        (if (.startsWith dir "/")
+                                        (if (.startsWith dir java.io.File/separator)
                                           [dir]
-                                          (map #(str % "/" dir) (boot/get-env :directories)))))
-                              (string/join ":"))]
+                                          (map #(perun/create-filepath % dir)
+                                               (boot/get-env :directories)))))
+                              (string/join ":"))
+        pod (create-pod content-deps)]
     (content-task
      {:render-form-fn (fn [data] `(io.perun.lessc/compile-less ~data ~include-dirs-str))
-      :paths-fn #(content-paths % options)
+      :paths-fn #(lessc-paths % options include-dirs-str pod)
       :passthru-fn content-passthru
       :task-name "lessc"
       :tracer :io.perun/lessc
-      :rm-originals true})))
+      :rm-originals true
+      :pod pod})))

--- a/src/io/perun/lessc.clj
+++ b/src/io/perun/lessc.clj
@@ -1,18 +1,38 @@
 (ns io.perun.lessc
-  (:require [io.perun.core :as perun]
+  (:require [clojure.string :as str]
+            [io.perun.core :as perun]
             [boot.from.me.raynes.conch :as conch]))
 
-(defn compile-less
-  [{:keys [entry]} include-dirs]
-  (perun/report-debug "lessc" "compiling lessc" (:path entry))
-  (let [lessc-args (->> [(when (seq include-dirs)
-                           (str "--include-path=" include-dirs))
-                         (:full-path entry)]
-                        (keep identity))
-        p (apply conch/proc "lessc" lessc-args)
-        css (conch/stream-to-string p :out)
+(defn lessc-out
+  [& args]
+  (let [p (apply conch/proc "lessc" args)
+        out (conch/stream-to-string p :out)
         err (conch/stream-to-string p :err)]
     (conch/destroy p)
     (when (not= (conch/exit-code p) 0)
       (perun/report-info "lessc" err))
-    (assoc entry :rendered css)))
+    out))
+
+(defn compile-less
+  [{:keys [entry]} include-dirs]
+  (perun/report-debug "lessc" "compiling less" (:path entry))
+  (let [lessc-args (->> [(when (seq include-dirs)
+                           (str "--include-path=" include-dirs))
+                         (:full-path entry)]
+                        (keep identity))]
+    (assoc entry :rendered (apply lessc-out lessc-args))))
+
+(defn lessc-deps
+  [{:keys [path full-path]} include-dirs]
+  (perun/report-debug "lessc" "getting deps" path)
+  (let [lessc-args (->> [(when (seq include-dirs)
+                           (str "--include-path=" include-dirs))
+                         "-M"
+                         full-path
+                         "perun-nowrite.css"]
+                        (keep identity))
+        deps (-> (apply lessc-out lessc-args)
+                 (str/replace #"^perun-nowrite\.css: " "")
+                 str/trim
+                 (str/split #" (?=/)"))]
+    (into #{} (remove empty? deps))))


### PR DESCRIPTION
It turns out that lessc has a relatively easy way of tracking dependencies for the files that it compiles, and we can leverage this to know when to recompile at a granular level.  There are no user-facing api changes.