### PR TITLE
Sort files by publish date in RSS feed.

### DIFF
--- a/src/io/perun/rss.clj
+++ b/src/io/perun/rss.clj
@@ -3,13 +3,15 @@
             [clj-rss.core  :as rss-gen]))
 
 (defn rss-definitions [files]
-  (for [file files]
-    {:link        (:canonical-url file)
-     :guid        (:canonical-url file)
-     :pubDate     (:date-published file)
-     :title       (:title file)
-     :description (:description file)
-     :author      (:author-email file)}))
+  (reverse
+   (sort-by :pubDate
+            (for [file files]
+              {:link        (:canonical-url file)
+               :guid        (:canonical-url file)
+               :pubDate     (:date-published file)
+               :title       (:title file)
+               :description (:description file)
+               :author      (:author-email file)}))))
 
 (defn generate-rss-str [files options]
   (let [rss-options  {:title       (:site-title options)


### PR DESCRIPTION
My rss feeds were generating entries in random order; this change allows
generating rss feeds consistently, sorted by the publish date set in the
entry.