### PR TITLE
Fix support for Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   effectively the same. These options have been unified to `out-dir`. ([#83][83])
 
 [83]: https://github.com/hashobject/perun/issues/83
+[hashobject/perun.io#28](hashobject/perun.io#28): Update dependencies to support Java 11
 
 ## 0.3.0 (2016-01-17)
 

--- a/Dockerfile_java11
+++ b/Dockerfile_java11
@@ -1,0 +1,6 @@
+FROM clojure:openjdk-11-boot
+ADD . /usr/src/perun
+WORKDIR /usr/src/perun
+RUN boot build
+WORKDIR /usr/src/app
+CMD ["boot","build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  perun-java11:
+    build:
+      context: .
+      dockerfile: Dockerfile_java11
+    volumes:
+      - ./examples/blog:/usr/src/app
+      - .:/usr/src/perun

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -58,7 +58,7 @@
   (filter filterer (meta-by-ext fileset extensions)))
 
 (def ^:private ^:deps print-meta-deps
-  '[[mvxcvi/puget "1.0.0"]])
+  '[[mvxcvi/puget "1.1.0"]])
 
 (def print-meta-pod (delay (create-pod' print-meta-deps)))
 
@@ -372,7 +372,7 @@
 
 (def ^:private ^:deps yaml-metadata-deps
   '[[org.clojure/tools.namespace "0.3.0-alpha3"]
-    [circleci/clj-yaml "0.5.5"]])
+    [circleci/clj-yaml "0.6.0"]])
 
 (def ^:private +yaml-metadata-defaults+
   {:filterer identity
@@ -400,8 +400,8 @@
 
 (def ^:private ^:deps markdown-deps
   '[[org.clojure/tools.namespace "0.3.0-alpha3"]
-    [com.vladsch.flexmark/flexmark "0.15.1"]
-    [com.vladsch.flexmark/flexmark-profile-pegdown "0.15.1"]])
+    [com.vladsch.flexmark/flexmark "0.40.16"]
+    [com.vladsch.flexmark/flexmark-profile-pegdown "0.40.16"]])
 
 (def ^:private +markdown-defaults+
   {:out-dir "public"
@@ -776,7 +776,7 @@
                  "based on the location of the file in the fileset\n"))))
 
 (def ^:private ^:deps sitemap-deps
-  '[[sitemap "0.2.4"]
+  '[[sitemap "0.3.0"]
     [clj-time "0.12.0"]])
 
 (def ^:private +sitemap-defaults+

--- a/src/io/perun/markdown.clj
+++ b/src/io/perun/markdown.clj
@@ -1,7 +1,8 @@
 (ns io.perun.markdown
   (:require [io.perun.core   :as perun]
             [clojure.java.io :as io])
-  (:import [com.vladsch.flexmark.html HtmlRenderer]
+  (:import [com.vladsch.flexmark Extension]
+           [com.vladsch.flexmark.html HtmlRenderer]
            [com.vladsch.flexmark.parser Parser]
            [com.vladsch.flexmark.profiles.pegdown Extensions PegdownOptionsAdapter]))
 
@@ -46,7 +47,9 @@
        int))
 
 (defn markdown-to-html [file-content extensions]
-  (let [flexmark-opts (PegdownOptionsAdapter/flexmarkOptions (extensions-map->int extensions))
+  (let [flexmark-opts (PegdownOptionsAdapter/flexmarkOptions
+                       (extensions-map->int extensions)
+                       (into-array Extension []))
         parser (.build (Parser/builder flexmark-opts))
         renderer (.build (HtmlRenderer/builder flexmark-opts))]
     (->> file-content


### PR DESCRIPTION
## Updates
- Updated dependencies such as clj-yaml, pugets, and flexmark
- Updated markdown task as the flexmark options adapter changed
- Added a Dockerfile_java11 file to test the example blog build in Java 11
- Added a compose file to organize the docker builds.
- Updated changelog

## Docker Compose

1. Run `docker-compose run perun-java11`
2. It will attempt to build the image and then the blog example.

## If it fails
1. Make changes to the perun source 
2. Run `docker-compose run perun-java11 bash`
3. Run `cd /usr/src/perun`
4. Run `boot install`
5. Run `cd /usr/src/app`
6. Run `boot build` to rebuild the blog with updated perun lib

I'm hoping we can use the docker compose file to organize other builds for testing purposes as cases increase. 