### PR TITLE
Default to https for gravatar links

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -19,7 +19,7 @@
 (require '[adzerk.bootlaces :refer :all])
 (require '[io.perun.core :refer [+version+]])
 (require '[io.perun-test])
-(require '[boot.test :refer [runtests]])
+(require '[boot.test :refer [runtests test-report test-exit]])
 
 (bootlaces! +version+)
 
@@ -57,3 +57,11 @@
     (watch)
     (repl :server true)
     (build)))
+
+(deftask test
+  "Run tests"
+  []
+  (comp
+    (runtests)
+    (test-report)
+    (test-exit)))

--- a/src/io/perun/gravatar.clj
+++ b/src/io/perun/gravatar.clj
@@ -4,7 +4,7 @@
 
 (defn add-gravatar [file source-prop target-prop]
   (if-let [email (get file source-prop)]
-    (assoc file target-prop (gr/avatar-url email))
+    (assoc file target-prop (gr/avatar-url email :https true))
     file))
 
 (defn find-gravatar [files source-prop target-prop]

--- a/test/io/perun_test.clj
+++ b/test/io/perun_test.clj
@@ -363,7 +363,7 @@ This --- be _asciidoc_.")
         (testing "gravatar"
           (value-check :path (perun/url-to-path "public/2017-01-01-test.html")
                        :value-fn
-                       #(meta= %1 %2 :gravatar "http://www.gravatar.com/avatar/a1a361f6c96acb1e31ad4b3bbf7aa444")
+                       #(meta= %1 %2 :gravatar "https://secure.gravatar.com/avatar/a1a361f6c96acb1e31ad4b3bbf7aa444")
                        :msg "`gravatar` should set `:gravatar` metadata"))
 
         (p/build-date)
@@ -554,7 +554,7 @@ This --- be _asciidoc_.")
         (testing "gravatar"
           (value-check :path (perun/url-to-path "hammock/test.htm")
                        :value-fn
-                       #(meta= %1 %2 :gravatar "http://www.gravatar.com/avatar/a1a361f6c96acb1e31ad4b3bbf7aa444")
+                       #(meta= %1 %2 :gravatar "https://secure.gravatar.com/avatar/a1a361f6c96acb1e31ad4b3bbf7aa444")
                        :msg "`gravatar` should set `:gravatar` metadata"))
 
         (p/build-date :filterer :markdown-set


### PR DESCRIPTION
It was old-style http and we want to default to https instead.

This also introduces the new `boot test` task with the right setup for
reporting and exiting correctly in case of failure.