### PR TITLE
Link to the more up to date guide for Perun

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Simple, composable static site generator built on top of the [Boot](http://boot-clj.com/).
 Inspired by Boot task model and [Metalsmith](http://www.metalsmith.io/).
 Perun is a collection of boot tasks that you can chain together and build something custom
-that suits your needs. Please checkout out [Getting started](https://github.com/hashobject/perun/wiki/Getting-Started) guide.
+that suits your needs. Please check out our [Getting Started](https://perun.io/guides/getting-started/) guide.
 
 ## For information and help
 


### PR DESCRIPTION
When I tried using Perun this morning, following the steps on the wiki resulted in lots of stack traces.

The wiki guide is now out of date, so I tried again with the published guides at the newer site - https://perun.io/guides/.

This worked, and seemed to use newer versions of everything, so I'm linking to the newer guide now.