### PR TITLE
Fix: RSS and Atom Feeds

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -2,6 +2,7 @@
   :source-paths #{"test"}
   :resource-paths #{"src"}
   :dependencies '[[boot/core "2.8.2" :scope "provided"]
+                  [org.clojure/clojure "1.10.1"]
                   [adzerk/boot-test "1.2.0" :scope "test"]
                   [adzerk/bootlaces "0.2.0" :scope "test"]])
 

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -1182,7 +1182,7 @@
 
 (def ^:private ^:deps atom-deps
   '[[org.clojure/tools.namespace "0.3.1"]
-    [org.clojure/data.xml "0.0.8"]
+    [org.clojure/data.xml "0.2.0-alpha6"]
     [clj-time "0.15.2"]])
 
 (def ^:private +atom-defaults+

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -1228,7 +1228,7 @@
       :pod (create-pod atom-deps)})))
 
 (def ^:private ^:deps rss-deps
-  '[[clj-rss "0.2.5"]
+  '[[clj-rss"0.2.6"]
     [clj-time "0.15.2"]])
 
 (def ^:private +rss-defaults+

--- a/src/io/perun.clj
+++ b/src/io/perun.clj
@@ -1182,7 +1182,7 @@
 
 (def ^:private ^:deps atom-deps
   '[[org.clojure/tools.namespace "0.3.1"]
-    [org.clojure/data.xml "0.2.0-alpha6"]
+    [org.clojure/data.xml "0.0.8"]
     [clj-time "0.15.2"]])
 
 (def ^:private +atom-defaults+

--- a/src/io/perun/atom.clj
+++ b/src/io/perun/atom.clj
@@ -42,48 +42,48 @@
         atom (xml/emit-str
               (xml/sexp-as-element
                [::atom/feed {:xmlns "http://www.w3.org/2005/Atom"}
-                [:title site-title]
+                [::atom/title site-title]
                 (when (seq description)
-                  [:subtitle description])
-                [:generator {:uri "https://perun.io/" :version version} "Perun"]
-                [:link {:href base-url :type "text/html"}]
-                [:link {:href canonical-url :rel "self"}]
-                [:link {:href (:first navs) :rel "first"}]
-                [:link {:href (:last navs) :rel "last"}]
+                  [::atom/subtitle description])
+                [::atom/generator {:uri "https://perun.io/" :version version} "Perun"]
+                [::atom/link {:href base-url :type "text/html"}]
+                [::atom/link {:href canonical-url :rel "self"}]
+                [::atom/link {:href (:first navs) :rel "first"}]
+                [::atom/link {:href (:last navs) :rel "last"}]
                 (when-let [next (:next navs)]
-                  [:link {:href next :rel "next"}])
+                  [::atom/link {:href next :rel "next"}])
                 (when-let [prev (:prev navs)]
-                  [:link {:href prev :rel "previous"}])
-                [:updated (->> entries
+                  [::atom/link {:href prev :rel "previous"}])
+                [::atom/updated (->> entries
                                (map (comp iso-datetime updated first))
                                sort
                                reverse
                                first)]
-                [:id base-url]
+                [::atom/id base-url]
 
                 (when global-author
-                  [:author
-                   [:name global-author]
+                  [::atom/author
+                   [::atom/name global-author]
                    (when global-author-email
-                     [:email global-author-email])])
+                     [::atom/email global-author-email])])
 
                 (for [{:keys [uuid canonical-url title author
                               author-email category tags content] :as post} entries
                       :let [author (or author global-author)
                             author-email (or author-email global-author-email)]]
-                  [:entry
-                   [:id (str "urn:uuid:" uuid)]
-                   [:title title]
+                  [::atom/entry
+                   [::atom/id (str "urn:uuid:" uuid)]
+                   [::atom/title title]
                    (when canonical-url
-                     [:link {:href canonical-url :type "text/html" :title title :rel "alternate"}])
-                   [:published (iso-datetime (published post))]
-                   [:updated (iso-datetime (updated post))]
-                   [:content {:type "html" :xml:base canonical-url} (str content)]
-                   [:author
-                    [:name author]
-                    (when author-email [:email author-email])]
+                     [::atom/link {:href canonical-url :type "text/html" :title title :rel "alternate"}])
+                   [::atom/published (iso-datetime (published post))]
+                   [::atom/updated (iso-datetime (updated post))]
+                   [::atom/content {:type "html" :xml:base canonical-url} (str content)]
+                   [::atom/author
+                    [::atom/name author]
+                    (when author-email [::atom/email author-email])]
                    (for [tag tags]
                    ;; FIXME: post-image media:thumbnail
-                     [:category {:term tag}])])]))]
+                     [::atom/category {:term tag}])])]))]
 
     (assoc entry :rendered atom)))

--- a/src/io/perun/atom.clj
+++ b/src/io/perun/atom.clj
@@ -28,6 +28,12 @@
        (map vector [:next :prev :first :last])
        (into {})))
 
+;; Declare a URI alias in this namespace
+;; Rationale: Remove the auto-generated namespace in the feed, because that will lead to invalid feeds. More documentation here:
+;;  - https://github.com/hashobject/perun/pull/251
+;;  - https://stackoverflow.com/questions/64611482/how-to-generate-a-xml-without-a-namespace-with-the-latest-version-of-org-clojure
+(xml/alias-uri 'atom "http://www.w3.org/2005/Atom")
+
 (defn generate-atom [{:keys [entry entries meta]}]
   (let [{:keys [site-title description base-url
                 canonical-url io.perun/version] :as options} (merge meta entry)
@@ -35,7 +41,7 @@
         navs (nav-hrefs options)
         atom (xml/emit-str
               (xml/sexp-as-element
-               [:feed {:xmlns "http://www.w3.org/2005/Atom"}
+               [::atom/feed {:xmlns "http://www.w3.org/2005/Atom"}
                 [:title site-title]
                 (when (seq description)
                   [:subtitle description])

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -5,7 +5,7 @@
             [boot.from.io.aviso.ansi :as ansi]
             [boot.util               :as u]))
 
-(def +version+ "0.4.4-SNAPSHOT")
+(def +version+ "0.4.3-SNAPSHOT")
 
 (defn report-info [task msg & args]
   (apply u/info

--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -5,7 +5,7 @@
             [boot.from.io.aviso.ansi :as ansi]
             [boot.util               :as u]))
 
-(def +version+ "0.4.3-SNAPSHOT")
+(def +version+ "0.4.4-SNAPSHOT")
 
 (defn report-info [task msg & args]
   (apply u/info

--- a/src/io/perun/rss.clj
+++ b/src/io/perun/rss.clj
@@ -40,20 +40,22 @@
                              (:canonical-url file)
                              "</a>"
                              "]]>")
-               :author      (or (:author-email file)
-                                ;; INFO: The RSS spec says it should
-                                ;; be one email, but many articles
-                                ;; have multiple authors.
-                                ;; INFO: The proper way would be to
-                                ;; include a "dc:creator" attribute
-                                ;; per author without email, however
-                                ;; clj-rss does not allow for that at
-                                ;; the moment:
-                                ;; https://github.com/yogthos/clj-rss/blob/1399a134d48f9a699e49edd9bc1d9250301a37fd/src/clj_rss/core.clj#L74.
-                                ;; For this reason, we're going with
-                                ;; an 'invalid' rss file which is read
-                                ;; by all tested feed readers, though.
-                                (:authors file))}))))
+               ;; INFO: The RSS spec says it should
+               ;; be one email, and does not say how to handle multiple authors.
+               ;; have multiple authors.
+               ;; INFO: The specified way would be to
+               ;; include a "dc:creator" attribute
+               ;; per author without email, however
+               ;; clj-rss does not allow for that:
+               ;; https://github.com/yogthos/clj-rss/blob/1399a134d48f9a699e49edd9bc1d9250301a37fd/src/clj_rss/core.clj#L74.
+               ;; For this reason, we're going to include one email
+               ;; address for potentially multiple authors.
+               ;; TODO: Join it here.
+               :author      (let [author (:author file)
+                                  author-email (:author-email file)]
+                              (if (and author author-email)
+                                (str (:author-email file) " (" author ")")
+                                author-email))}))))
 
 (defn generate-rss-str [files options]
   (let [rss-options  {:title       (:site-title options)

--- a/src/io/perun/rss.clj
+++ b/src/io/perun/rss.clj
@@ -13,8 +13,8 @@
   (reverse
    ;; INFO: Whilst the `:date-published` is in RFC 822 format (i.e.
    ;; Sat, 10 Oct 2020 02:00:00 +0200), having a 'correct' sort is
-   ;; relevant. Otherwise feed readers interestingly will display an
-   ;; ordering by the names of week days.
+   ;; relevant. Otherwise some feed readers interestingly will display
+   ;; an ordering by the names of week days.
    (sort-by #(iso-datetime (:pubDate %))
             (for [file files]
               {:link        (:canonical-url file)
@@ -23,34 +23,23 @@
                :title       (:title file)
                ;; FIXME: Why is there no `:content` attribute
                ;; available? In the `:content`, there would be the
-               ;; whole post. The `atom` task has `:content`
-               ;; available.
-               ;; :description (str
+               ;; whole post.
+               ;; https://www.rssboard.org/rss-profile#namespace-elements-content-encoded
+               ;; :content (str
                ;;               "<![CDATA["
-               ;;               (:content file)
+               ;;               ("content:encoded" file)
                ;;               "]]>")
+               ;; :description can hold HTML (https://www.rssboard.org/rss-profile#data-types-characterdata) and hence wrapped in cdata.
                :description (str
                              "<![CDATA["
-                             "Description: "
                              (:description file)
-                             "<br><br>"
-                             "Read the full article here: <a href=\""
-                             (:canonical-url file)
-                             "\">"
-                             (:canonical-url file)
-                             "</a>"
                              "]]>")
-               ;; INFO: The RSS spec says it should
-               ;; be one email, and does not say how to handle multiple authors.
-               ;; have multiple authors.
-               ;; INFO: The specified way would be to
-               ;; include a "dc:creator" attribute
-               ;; per author without email, however
-               ;; clj-rss does not allow for that:
+               ;; INFO: The old RSS v1 spec assumes one blog post has one
+               ;; author who is identified via one author-email.
+               ;; INFO: The new RSS v2 spec includes a a "dc:creator"
+               ;; attribute per author without email, however clj-rss
+               ;; does not allow for that:
                ;; https://github.com/yogthos/clj-rss/blob/1399a134d48f9a699e49edd9bc1d9250301a37fd/src/clj_rss/core.clj#L74.
-               ;; For this reason, we're going to include one email
-               ;; address for potentially multiple authors.
-               ;; TODO: Join it here.
                :author      (let [author (:author file)
                                   author-email (:author-email file)]
                               (if (and author author-email)

--- a/src/io/perun/rss.clj
+++ b/src/io/perun/rss.clj
@@ -44,6 +44,15 @@
                                 ;; INFO: The RSS spec says it should
                                 ;; be one email, but many articles
                                 ;; have multiple authors.
+                                ;; INFO: The proper way would be to
+                                ;; include a "dc:creator" attribute
+                                ;; per author without email, however
+                                ;; clj-rss does not allow for that at
+                                ;; the moment:
+                                ;; https://github.com/yogthos/clj-rss/blob/1399a134d48f9a699e49edd9bc1d9250301a37fd/src/clj_rss/core.clj#L74.
+                                ;; For this reason, we're going with
+                                ;; an 'invalid' rss file which is read
+                                ;; by all tested feed readers, though.
                                 (:authors file))}))))
 
 (defn generate-rss-str [files options]


### PR DESCRIPTION
Both Atom and RSS feeds had some issues. This PR is not a perfect solution, but it improves the situation quite a bit.

Changes for Atom:

- Atom feeds were not valid before. The rather old version of `clojure.data.xml` library would render `<feed xmlns:a="http://www.w3.org/2005/Atom">` instead of `<feed xmlns="http://www.w3.org/2005/Atom">` (notice the `:a` namespace). Whilst this doesn't look like a huge issue, it leads to various issues:

  - https://validator.w3.org/feed/ would not deem the feed valid

![image](https://user-images.githubusercontent.com/505721/96772798-f1ca4100-13e3-11eb-9517-c9b8c4553100.png)

  - The feed would be rejected by various feed readers (i.e. Thunderbird and Miniflux).

![image](https://user-images.githubusercontent.com/505721/96772972-2fc76500-13e4-11eb-837a-cde59c0471a7.png)

  - Other feed readers would show 'random' errors. For example feedbin.com will skip various posts whilst showing others.

The issue was not trivial to fix, because the docs of `clojure.data.xml` state namespaces as a new feature. And this new syntax would not work on the old version. Finally, I realized that upgrading to the current version would give me access to said syntax. And since atom.clj is not specifying any namespace, now none is rendered and will make the Atom feed valid.

Unfortunately, the tests are now breaking. They run very slow for me and I don't know how to debug them. Hence, I left them broken (apologies). Simply reverting the clojure.data.xml version will make the tests run again, but then the feed will not be valid.

If someone teaches me how to run perun with Cider so that I can do some debugging or run just one test, I'd be happy to give that a shot at some point.

Changes for RSS:

Firstly, they are not nearly as huge as the Atom issue(;

- The sort order of posts in many feed readers was random, because the sort order happend on the name of the week day instead of the date. There's more information inline in the code.

- It would be nice to have included the complete content of the post into the RSS feed, but I'm lacking the necessary knowledge to do that in Perun. The `:content` attribute for a post is not accessible in rss.clj; it is in atom.clj, though. I've added the necessary boilerplate.

- It would be nice to support multiple authors, but since the used clj-rss library does not support it, I've only left informative comments for the next dev checking that out.

- The RSS spec allows for "author" and "author-email" to be given as meta-date. I've added the specified syntax.

---

As a result, both RSS and Atom feeds for 200ok.ch are valid now:

- https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2F200ok.ch%2Fatom.xml
- https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2F200ok.ch%2Frss.xml

Both still have recommondations that could be addressed, but at least they are valid and work for all tested feed readers - including the ones that silently didn't work for one reason or another(;