### PR TITLE
Deploy snapshots at each commit on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,9 +127,7 @@ workflows:
               jdk-executor: ["openjdk-8"]
           filters: &filters-snapshot
             branches:
-              ignore: /.*/
-            tags:
-              only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-SNAPSHOT/
+              only: master
       - deploy-snapshot:
           requires:
             - test-and-build

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,16 +1,15 @@
 # Maintainers Guide
 
-This guide is intended for *maintainers* — anybody with commit access to the repository.
-
-Maintainers can choose to release new maintenance releases with each new patch, or accumulate
-patches until a significant number of changes are in place.
+This guide is intended for *maintainers* — anybody with commit access to the
+repository.
 
 ## Workflow for releasing
 
 ### Update the Changelog
 
 You would need to convert the `Unreleased` section to a tagged (released)
-section and fill up the missing entries, if Pull Request authors have not done it themselves already.
+section and fill up the missing entries, if Pull Request authors have not done
+it themselves already.
 
 The CHANGELOG.md files should looks similar to this:
 
@@ -43,30 +42,33 @@ The CHANGELOG.md files should looks similar to this:
   Something to be Better.
 ```
 
-Each version gets a changelog entry in the project's `CHANGELOG.md` file. Not all changes need to be
-noted; things like coding standards fixes, continuous integration changes, or typo fixes do not need
-to be communicated. However, anything that falls under an addition, deprecation, removal, or fix
-MUST be noted. Please provide a succinct but *narrative* description for the change you merge. Once
-written, commit the `CHANGELOG.md` file against your local branch.
+Each version gets a changelog entry in the project's `CHANGELOG.md` file. Not
+all changes need to be noted; things like coding standards fixes, continuous
+integration changes, or typo fixes do not need to be communicated. However,
+anything that falls under an addition, deprecation, removal, or fix MUST be
+noted. Please provide a succinct but *narrative* description for the change you
+merge. Once written, commit the `CHANGELOG.md` file against your local branch.
 
-### Deploy the artifact
+### Deploy release artifact
 
-In order to deploy either a release or a snapshot from the `master` branch (the
-only allowed) , we need to accomplish two things:
+In order to deploy a release jar to Clojars, we need to accomplish two things:
 
-    * update the `version.properties` file, for instance:
-    * tag a commit (preferably both tag and commit should be signed):
+    * update the `version.properties` file
+    * tag a commit (preferably both tag and commit should be signed)
 
-On linux/bash, this can be accomplished with the following commands:
+This can be accomplished with the following commands:
 
 ```shell
-boot version --patch inc --pre-release snapshot
+boot version --patch inc --pre-release empty
 perun_version=$(grep "VERSION" version.properties | cut -d'=' -f2)
 git commit --all --message "Release $perun_version"
 git tag --sign "$perun_version" --message "Release $perun_version"
 ```
 
-At this point you are ready to push everything:
+Of course the messages can be arbitrary but we recommend following the above
+guideline.
+
+Once that's done you are ready to push everything:
 
 ```shell
 git push --follow-tags
@@ -75,4 +77,18 @@ git push --follow-tags
 The CI/CD pipeline will take care of the rest, you can check the progress at:
 
 https://app.circleci.com/pipelines/github/hashobject
+
+## Workflow for snapshots
+
+A snapshot artifact will be deployed every time a commit is pushed to master.
+
+The CI/CD pipeline validates that the version in `version.properties` contains
+the `-SNAPSHOT` suffix. The pipeline fails if missing.
+
+After a release you would usually bump the version and assign it the suffix
+this way:
+
+```shell
+boot version --patch inc --pre-release snapshot
+```
 


### PR DESCRIPTION
I realized it is easier to just deploy a snapshot for each merged commit.

This PR also fixes the `MAINTAINERS.md` file.