### PR TITLE
Make sure we read version.properties from the jar, fixes #254

### DIFF
--- a/src/io/perun/core.clj
+++ b/src/io/perun/core.clj
@@ -10,7 +10,9 @@
 (defn perun-version
   []
   (let [m (doto (java.util.Properties.)
-            (.load ^java.io.Reader (io/reader +version-file-name+)))]
+            (.load ^java.io.Reader (-> (or (io/resource +version-file-name+)
+                                           (io/file +version-file-name+))
+                                       io/reader)))]
     (if-let [[k v] (find m "VERSION")]
       v
       (throw (Exception. (str "The " +version-file-name+ " file does not contain a VERSION property, this is a bug."))))))


### PR DESCRIPTION
The bug was that we were not using io/resource on the file and therefore we
could not read it when embedded in the jar.